### PR TITLE
✨ 찾아오는 길 추가

### DIFF
--- a/apis/directions.ts
+++ b/apis/directions.ts
@@ -1,0 +1,15 @@
+import { Direction } from '@/types/directions';
+
+import { getRequest } from '.';
+
+const directionsPath = '/directions';
+
+export const getDirections = () => getRequest(directionsPath) as Promise<Direction[]>;
+
+export const getDirectionsMock = () => DIRECTIONS_MOCK;
+
+const DIRECTIONS_MOCK: Direction[] = [
+  { name: '대중교통', engName: 'public-transit', description: '대중교통으로 오는 방법 어쩌고' },
+  { name: '승용차', engName: 'car', description: '승용차로 오는 방법 어쩌고' },
+  { name: '지방 및 해외', engName: 'far-away', description: '지방 및 해외에서 오는 방법 어쩌고' },
+];

--- a/apis/directions.ts
+++ b/apis/directions.ts
@@ -9,7 +9,28 @@ export const getDirections = () => getRequest(directionsPath) as Promise<Directi
 export const getDirectionsMock = () => DIRECTIONS_MOCK;
 
 const DIRECTIONS_MOCK: Direction[] = [
-  { name: '대중교통', engName: 'public-transit', description: '대중교통으로 오는 방법 어쩌고' },
+  {
+    name: '대중교통',
+    engName: 'public-transit',
+    description: `<div>
+<h3>대중교통으로 오는 방법</h3>
+  <section>
+    <h4>지하철 2호선 낙성대역</h4>
+    <p>
+      낙성대역 4번 출구로 나와 직진, 주유소에서 좌회전하여 제과점 앞 정류장에서 마을버스
+      관악02를 타고 신공학관에서 내립니다.
+    </p>
+  </section>
+  <section>
+    <h4>지하철 2호선 서울대입구역</h4>
+    <p>
+      서울대입구역 3번 출구로 나와 관악구청 방향으로 직진하여 학교 셔틀 버스나 시내버스 5511
+      또는 5513을 타고 신공학관에서 내립니다. 신공학관행 셔틀버스는 앙침 8시부터 10시까지
+      15분 간격으로 월요일부터 금요일까지 운행합니다.
+    </p>
+  </section>
+</div>`,
+  },
   { name: '승용차', engName: 'car', description: '승용차로 오는 방법 어쩌고' },
   { name: '지방 및 해외', engName: 'far-away', description: '지방 및 해외에서 오는 방법 어쩌고' },
 ];

--- a/app/about/directions/page.tsx
+++ b/app/about/directions/page.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 import { getDirections, getDirectionsMock } from '@/apis/directions';
 
 import HTMLViewer from '@/components/common/HTMLViewer';

--- a/app/about/directions/page.tsx
+++ b/app/about/directions/page.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+
+import { getDirections, getDirectionsMock } from '@/apis/directions';
+
+import HTMLViewer from '@/components/common/HTMLViewer';
+import DirectionsList from '@/components/directions/DirectionList';
+import PageLayout from '@/components/layout/PageLayout';
+
+import { directions, staff } from '@/types/page';
+
+import { getPath } from '@/utils/page';
+
+interface DirectionsPageProps {
+  searchParams: { selected?: string };
+}
+
+const DEFAULT_DIRECITON = 'public-transit';
+const staffPath = getPath(staff);
+
+export default async function DirectionsPage({ searchParams }: DirectionsPageProps) {
+  const selected = searchParams.selected ? decodeURI(searchParams.selected) : DEFAULT_DIRECITON;
+  const { directionList, selectedDirection } = await getData(selected);
+
+  return (
+    <PageLayout currentPage={directions} title={directions.name} titleSize="text-2xl">
+      <p className="mb-[3.25rem] font-noto text-sm leading-6">
+        컴퓨터공학부는 서울대학교 관악 301동(신공학관1)에 있습니다.
+        <br />
+        주소: 08826 서울특별시 관악구 관악로 1 서울대학교 공과대학 컴퓨터공학부 행정실(301동 316호)
+        <br />
+        전화:{' '}
+        <Link href={staffPath} className="underline text-link">
+          학부 연락처
+        </Link>
+      </p>
+      <div>
+        <DirectionsList directionsList={directionList} selectedDirections={selectedDirection} />
+        {selectedDirection && <HTMLViewer htmlContent={selectedDirection.description} />}
+      </div>
+    </PageLayout>
+  );
+}
+
+export async function getData(selectedDirectionEngName: string) {
+  // const directions = await getDirections();
+  const directionList = getDirectionsMock();
+  const selectedDirection = directionList.find((dir) => dir.engName === selectedDirectionEngName);
+  return { directionList, selectedDirection };
+}

--- a/app/about/directions/page.tsx
+++ b/app/about/directions/page.tsx
@@ -4,18 +4,16 @@ import { getDirections, getDirectionsMock } from '@/apis/directions';
 
 import HTMLViewer from '@/components/common/HTMLViewer';
 import DirectionsList from '@/components/directions/DirectionList';
+import LocationInformation from '@/components/directions/LocationInformation';
 import PageLayout from '@/components/layout/PageLayout';
 
-import { directions, staff } from '@/types/page';
-
-import { getPath } from '@/utils/page';
+import { directions } from '@/types/page';
 
 interface DirectionsPageProps {
   searchParams: { selected?: string };
 }
 
 const DEFAULT_DIRECITON = 'public-transit';
-const staffPath = getPath(staff);
 
 export default async function DirectionsPage({ searchParams }: DirectionsPageProps) {
   const selected = searchParams.selected ? decodeURI(searchParams.selected) : DEFAULT_DIRECITON;
@@ -23,16 +21,7 @@ export default async function DirectionsPage({ searchParams }: DirectionsPagePro
 
   return (
     <PageLayout currentPage={directions} title={directions.name} titleSize="text-2xl">
-      <p className="mb-[3.25rem] font-noto text-sm leading-6">
-        컴퓨터공학부는 서울대학교 관악 301동(신공학관1)에 있습니다.
-        <br />
-        주소: 08826 서울특별시 관악구 관악로 1 서울대학교 공과대학 컴퓨터공학부 행정실(301동 316호)
-        <br />
-        전화:{' '}
-        <Link href={staffPath} className="underline text-link">
-          학부 연락처
-        </Link>
-      </p>
+      <LocationInformation />
       <div>
         <DirectionsList directionsList={directionList} selectedDirections={selectedDirection} />
         {selectedDirection && <HTMLViewer htmlContent={selectedDirection.description} />}

--- a/app/about/directions/page.tsx
+++ b/app/about/directions/page.tsx
@@ -25,7 +25,7 @@ export default async function DirectionsPage({ searchParams }: DirectionsPagePro
         <LocationMap />
       </div>
       <div>
-        <DirectionsList directionsList={directionList} selectedDirections={selectedDirection} />
+        <DirectionsList directionsList={directionList} selectedDirection={selectedDirection} />
         {selectedDirection && <HTMLViewer htmlContent={selectedDirection.description} />}
       </div>
     </PageLayout>

--- a/app/about/directions/page.tsx
+++ b/app/about/directions/page.tsx
@@ -2,7 +2,8 @@ import { getDirections, getDirectionsMock } from '@/apis/directions';
 
 import HTMLViewer from '@/components/common/HTMLViewer';
 import DirectionsList from '@/components/directions/DirectionList';
-import LocationInformation from '@/components/directions/LocationInformation';
+import LocationGuide from '@/components/directions/LocationGuide';
+import LocationMap from '@/components/directions/LocationMap';
 import PageLayout from '@/components/layout/PageLayout';
 
 import { directions } from '@/types/page';
@@ -19,7 +20,10 @@ export default async function DirectionsPage({ searchParams }: DirectionsPagePro
 
   return (
     <PageLayout currentPage={directions} title={directions.name} titleSize="text-2xl">
-      <LocationInformation />
+      <div className="mb-[3.25rem]">
+        <LocationGuide />
+        <LocationMap />
+      </div>
       <div>
         <DirectionsList directionsList={directionList} selectedDirections={selectedDirection} />
         {selectedDirection && <HTMLViewer htmlContent={selectedDirection.description} />}

--- a/app/about/student-clubs/page.tsx
+++ b/app/about/student-clubs/page.tsx
@@ -7,11 +7,13 @@ import ClubList from '@/components/studentClubs/ClubList';
 import { studentClubs } from '@/types/page';
 
 interface StudentClubsPageProps {
-  searchParams: { selected: string | undefined };
+  searchParams: { selected?: string };
 }
 
+const DEFAULT_CLUB = '와플스튜디오';
+
 export default async function StudentClubsPage({ searchParams }: StudentClubsPageProps) {
-  const selected = searchParams.selected ? decodeURI(searchParams.selected) : '와플스튜디오';
+  const selected = searchParams.selected ? decodeURI(searchParams.selected) : DEFAULT_CLUB;
   const { clubs, selectedClub } = await getData(selected);
 
   return (

--- a/app/community/news/page.tsx
+++ b/app/community/news/page.tsx
@@ -10,12 +10,13 @@ import SearchForm from '@/components/common/search/SearchForm';
 import PageLayout from '@/components/layout/PageLayout';
 import NewsRow from '@/components/news/NewsRow';
 
+import { NewsTags } from '@/constants/tag';
+
 import { useCustomSearchParams } from '@/hooks/useCustomSearchParams';
 import { useQueryString } from '@/hooks/useQueryString';
 
 import { news } from '@/types/page';
 import { GETNewsPostsResponse } from '@/types/post';
-import { NewsTags } from '@/constants/tag';
 
 import { getPath } from '@/utils/page';
 

--- a/app/community/notice/[id]/page.tsx
+++ b/app/community/notice/[id]/page.tsx
@@ -38,8 +38,7 @@ export default function NoticePostPage() {
     noticePath,
     getNoticePostDetail,
   );
-  const { curr, prev, next } = posts;
-  const currPost = curr || NoticeDetailMock;
+  const { curr = NoticeDetailMock, prev, next } = posts;
 
   return (
     <PageLayout
@@ -49,11 +48,11 @@ export default function NoticePostPage() {
     >
       <div className="mb-6 text-xs font-yoon text-neutral-400 ml-2.5">
         글쓴이: {writer}, 작성시각:{' '}
-        {formatDate(new Date(currPost.createdAt), { includeDay: true, includeTime: true })}
+        {formatDate(new Date(curr.createdAt), { includeDay: true, includeTime: true })}
       </div>
       <div className="border w-auto h-[300px] mb-10 ml-2.5"></div>
       <StraightNode />
-      <Tags tags={currPost.tags} page={notice} margin="mt-3 ml-6" />
+      <Tags tags={curr.tags} page={notice} margin="mt-3 ml-6" />
       <AdjPostNav prevPost={prev} nextPost={next} href={listPathWithQuery} margin="mt-12" />
     </PageLayout>
   );

--- a/app/community/notice/page.tsx
+++ b/app/community/notice/page.tsx
@@ -10,11 +10,12 @@ import SearchForm from '@/components/common/search/SearchForm';
 import PageLayout from '@/components/layout/PageLayout';
 import NoticeList from '@/components/notice/NoticeList';
 
+import { NoticeTags } from '@/constants/tag';
+
 import { useCustomSearchParams } from '@/hooks/useCustomSearchParams';
 
 import { notice } from '@/types/page';
 import { SimpleNoticePost } from '@/types/post';
-import { NoticeTags } from '@/constants/tag';
 
 const NoticeMockLong: SimpleNoticePost = {
   id: 1,

--- a/components/directions/DirectionList.tsx
+++ b/components/directions/DirectionList.tsx
@@ -2,36 +2,45 @@ import Link from 'next/link';
 
 import { COLOR_THEME } from '@/constants/color';
 
-import { Club } from '@/types/club';
-import { studentClubs } from '@/types/page';
+import { Direction } from '@/types/directions';
+import { directions } from '@/types/page';
 
 import { getPath } from '@/utils/page';
 
 import CornerFoldedRectangle from '../common/CornerFoldedRectangle';
 
-interface ClubListProps {
-  clubs: Club[];
-  selectedClub?: Club;
+interface DirectionsListProps {
+  directionsList: Direction[];
+  selectedDirections?: Direction;
 }
 
-export default function ClubList({ clubs, selectedClub }: ClubListProps) {
+export default function DirectionsList({
+  directionsList,
+  selectedDirections,
+}: DirectionsListProps) {
   return (
-    <ul className="grid grid-cols-4 gap-3 mb-8">
-      {clubs.map((club) => (
-        <ClubItem key={club.name} name={club.name} isSelected={selectedClub?.name === club.name} />
+    <ul className="flex gap-3 mb-8">
+      {directionsList.map((d) => (
+        <DirectionsItem
+          key={d.name}
+          name={d.name}
+          engName={d.engName}
+          isSelected={selectedDirections?.name === d.name}
+        />
       ))}
     </ul>
   );
 }
 
-interface ClubItemProps {
+interface DirectionsItemProps {
   name: string;
+  engName: string;
   isSelected: boolean;
 }
 
-const clubPath = getPath(studentClubs);
+const directionsPath = getPath(directions);
 
-function ClubItem({ name, isSelected }: ClubItemProps) {
+function DirectionsItem({ name, engName, isSelected }: DirectionsItemProps) {
   const itemCommonStyle = 'w-[12.5625rem] h-10 py-3 text-center text-sm tracking-wide font-yoon';
   const dropShadow = 'drop-shadow(1px 2px 4px rgba(0,0,0,0.25)';
 
@@ -50,7 +59,7 @@ function ClubItem({ name, isSelected }: ClubItemProps) {
   ) : (
     <li>
       <Link
-        href={`${clubPath}?selected=${name}`}
+        href={`${directionsPath}?selected=${engName}`}
         className={`${itemCommonStyle} block bg-neutral-100 text-neutral-500`}
       >
         {name}

--- a/components/directions/DirectionList.tsx
+++ b/components/directions/DirectionList.tsx
@@ -61,6 +61,7 @@ function DirectionsItem({ name, engName, isSelected }: DirectionsItemProps) {
       <Link
         href={`${directionsPath}?selected=${engName}`}
         className={`${itemCommonStyle} block bg-neutral-100 text-neutral-500`}
+        scroll={false} // 안 먹힘
       >
         {name}
       </Link>

--- a/components/directions/DirectionList.tsx
+++ b/components/directions/DirectionList.tsx
@@ -11,12 +11,12 @@ import CornerFoldedRectangle from '../common/CornerFoldedRectangle';
 
 interface DirectionsListProps {
   directionsList: Direction[];
-  selectedDirections?: Direction;
+  selectedDirection?: Direction;
 }
 
 export default function DirectionsList({
   directionsList,
-  selectedDirections,
+  selectedDirection: selectedDirection,
 }: DirectionsListProps) {
   return (
     <ul className="flex gap-3 mb-8">
@@ -25,7 +25,7 @@ export default function DirectionsList({
           key={d.name}
           name={d.name}
           engName={d.engName}
-          isSelected={selectedDirections?.name === d.name}
+          isSelected={selectedDirection?.name === d.name}
         />
       ))}
     </ul>

--- a/components/directions/LocationGuide.tsx
+++ b/components/directions/LocationGuide.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+import { staff } from '@/types/page';
+
+import { getPath } from '@/utils/page';
+
+const staffPath = getPath(staff);
+
+export default function LocationGuide() {
+  return (
+    <p className="font-noto text-sm leading-6 mb-8">
+      컴퓨터공학부는 서울대학교 관악 301동(신공학관1)에 있습니다.
+      <br />
+      주소: 08826 서울특별시 관악구 관악로 1 서울대학교 공과대학 컴퓨터공학부 행정실(301동 316호)
+      <br />
+      전화:{' '}
+      <Link href={staffPath} className="underline text-link">
+        학부 연락처
+      </Link>
+    </p>
+  );
+}

--- a/components/directions/LocationInformation.tsx
+++ b/components/directions/LocationInformation.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+import { staff } from '@/types/page';
+
+import { getPath } from '@/utils/page';
+
+const staffPath = getPath(staff);
+
+export default function LocationInformation() {
+  return (
+    <div className="mb-[3.25rem]">
+      <LocationAddress />
+      <LocationMap />
+    </div>
+  );
+}
+
+function LocationAddress() {
+  return (
+    <p className="font-noto text-sm leading-6 mb-8">
+      컴퓨터공학부는 서울대학교 관악 301동(신공학관1)에 있습니다.
+      <br />
+      주소: 08826 서울특별시 관악구 관악로 1 서울대학교 공과대학 컴퓨터공학부 행정실(301동 316호)
+      <br />
+      전화:{' '}
+      <Link href={staffPath} className="underline text-link">
+        학부 연락처
+      </Link>
+    </p>
+  );
+}
+
+function LocationMap() {
+  return <div>map</div>;
+}

--- a/components/directions/LocationInformation.tsx
+++ b/components/directions/LocationInformation.tsx
@@ -1,10 +1,12 @@
+'use client';
+
 import Link from 'next/link';
+import Script from 'next/script';
+import { useEffect, useRef } from 'react';
 
 import { staff } from '@/types/page';
 
 import { getPath } from '@/utils/page';
-
-const staffPath = getPath(staff);
 
 export default function LocationInformation() {
   return (
@@ -14,6 +16,8 @@ export default function LocationInformation() {
     </div>
   );
 }
+
+const staffPath = getPath(staff);
 
 function LocationAddress() {
   return (
@@ -30,6 +34,44 @@ function LocationAddress() {
   );
 }
 
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+const LATITUDE = 37.449996;
+const LONGITUDE = 126.952509;
+
 function LocationMap() {
-  return <div>map</div>;
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const initializeMap = () => {
+    if (containerRef.current) {
+      const options = {
+        center: new window.kakao.maps.LatLng(LATITUDE, LONGITUDE),
+        level: 3,
+      };
+      const map = new window.kakao.maps.Map(containerRef.current, options);
+      const markerPosition = new window.kakao.maps.LatLng(LATITUDE, LONGITUDE);
+      const marker = new window.kakao.maps.Marker({ position: markerPosition });
+      marker.setMap(map);
+    }
+  };
+
+  useEffect(() => {
+    if (window.kakao) {
+      initializeMap();
+    }
+  }, []);
+
+  return (
+    <>
+      <Script
+        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&autoload=false`}
+        onLoad={() => window.kakao.maps.load(initializeMap)}
+      />
+      <div id="map" className="h-80" ref={containerRef}></div>
+    </>
+  );
 }

--- a/components/directions/LocationMap.tsx
+++ b/components/directions/LocationMap.tsx
@@ -1,38 +1,7 @@
 'use client';
 
-import Link from 'next/link';
 import Script from 'next/script';
 import { useEffect, useRef } from 'react';
-
-import { staff } from '@/types/page';
-
-import { getPath } from '@/utils/page';
-
-export default function LocationInformation() {
-  return (
-    <div className="mb-[3.25rem]">
-      <LocationAddress />
-      <LocationMap />
-    </div>
-  );
-}
-
-const staffPath = getPath(staff);
-
-function LocationAddress() {
-  return (
-    <p className="font-noto text-sm leading-6 mb-8">
-      컴퓨터공학부는 서울대학교 관악 301동(신공학관1)에 있습니다.
-      <br />
-      주소: 08826 서울특별시 관악구 관악로 1 서울대학교 공과대학 컴퓨터공학부 행정실(301동 316호)
-      <br />
-      전화:{' '}
-      <Link href={staffPath} className="underline text-link">
-        학부 연락처
-      </Link>
-    </p>
-  );
-}
 
 declare global {
   interface Window {
@@ -43,7 +12,7 @@ declare global {
 const LATITUDE = 37.449996;
 const LONGITUDE = 126.952509;
 
-function LocationMap() {
+export default function LocationMap() {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const initializeMap = () => {

--- a/types/directions.ts
+++ b/types/directions.ts
@@ -1,0 +1,5 @@
+export interface Direction {
+  name: string;
+  engName: string;
+  description: string;
+}


### PR DESCRIPTION
## 미리보기
<img width="833" alt="KakaoTalk_20230809_032824543_01" src="https://github.com/wafflestudio/csereal-web/assets/92114639/8a49d796-3d23-4526-8f19-db935c33f13c">
<img width="833" alt="KakaoTalk_20230809_032824543_02" src="https://github.com/wafflestudio/csereal-web/assets/92114639/7cb2d592-5a9c-4b0e-ac1e-0ae103dc90d6">

## 요약
- 찾아오는 길 추가
- 카카오맵 api 사용

## 상세
### 찾아오는 길 추가
- `DirectionsPage`
- 찾아오는 길 페이지를 추가했습니다.
- 별거 없습니다.
- 동아리와 동일하게, 찾아오는 길에 대한 설명 서버에서 전부 불러와서 프론트단에서 그냥 필터링하는 구조입니다. 어차피 3개밖에 없으니 별 문제는 없을 듯합니다.
- 탭(대중교통, 승용차, 지방 및 해외)이 지도 밑에 있으니 다른 탭 눌렀을 때 스크롤 위치가 유지되도록 하고 싶었는데, 왜인지 `<Link scroll={false}>`가 안 먹혀서 일단 페이지 바뀔 때마다 맨 위로 자동 스크롤되는 상황입니다. 사용자가 조금 불편하긴 하겠지만 당장에 고쳐야 할 큰 이슈는 아니니, 방법을 찾게 된다면 수정하도록 하겠습니다.😢
- 여기까지는 api 요청에 axios 썼는데, fetch 알아보고 다른 pr에서 몰래 같이 바꿔놓겠습니다.🤣

### 카카오맵 api
- `LocationMap`
- 여기도 `useEffect` 썼는데, `useSWR` 좀 알아보고 다른 pr에서 같이 바꿔놓을게요!
- api 쓰려면 키를 발급받아야 해서, 일단 제 이름으로 받았습니다. 이거 어떻게 할지는 나중에 생각해봐도 될 것 같습니다.
- 위에서 말한 키를 코드에 그대로 넣으면 보안상 문제가 생길 수도 있을 것 같아서, `.env.local` 만들고 넣어두었습니다. 이건 gitignore에 있는 파일이라 깃허브에 안 올라갔을 거예요.

## 사소한 논의사항
- 페이지 이름이 `directions`라서 대중교통, 승용차 이런 것들 명칭도 `direction`으로 해놓긴 했는데 뭔가... 어색함... 굳이 의미를 끼워 맞추자면 합리화할 수는 있겠으나 뭔가... 어색함... 하지만 중요한 건 아니니 명칭 그냥 이렇게 냅둘까요. 사실 분류도 좀 이상하긴 함. 앞에 두 개가 '대중교통', '승용차'라면 그 다음도 '기차', '비행기' 이런 교통수단 이름이 와야 할 것 같은데 '지방 및 해외'라서 뭔가... 종류가 좀 달라...
- 오는 방법 정보를 담고 있는 `Direction` 타입을 `types/directions`에 넣어놨는데 타입 하나 쓰자고 파일을 새로 만들었다...? 근데 이걸 `post`에 넣기에는 안 어울리는 것 같아서 일단 파일 새로 팠어요. 포스트는 공지글이나 새소식, 세미나 글처럼 개별 아이디가 있는 글인 느낌이라,,, 이거 지금처럼 그냥 `types/directions`에 냅둘지, 다른 좋은 방법이 있을지? (참고로 컴포넌트 파일에 타입을 선언해두자니 api 파일에서도 쓰이는 타입이라 어색할 것 같아서 그냥 `types`에 넣음)