### PR TITLE
✨ 연락처 페이지 추가

### DIFF
--- a/apis/contact.ts
+++ b/apis/contact.ts
@@ -6,7 +6,7 @@ const contactPath = '/contact';
 export const getContact = () => getRequest(contactPath) as Promise<ContactResponse>;
 
 export const getMockContact: typeof getContact = async () => {
-  const contact = {
+  return {
     mainImage:
       'https://cse.snu.ac.kr/sites/default/files/styles/scale-width-220/public/node--contact/301.jpg?itok=zbUgVCfd',
     address: '08826 서울특별시 관악구 관악로 1 (301동 316호)',
@@ -20,5 +20,4 @@ export const getMockContact: typeof getContact = async () => {
       { name: '채용정보 게시요청', email: 'bulletin@cse.snu.ac.kr' },
     ],
   };
-  return contact;
 };

--- a/apis/contact.ts
+++ b/apis/contact.ts
@@ -1,0 +1,24 @@
+import { ContactResponse } from '@/types/contact';
+
+import { getRequest } from '.';
+
+const contactPath = '/contact';
+export const getContact = () => getRequest(contactPath) as Promise<ContactResponse>;
+
+export const getMockContact: typeof getContact = async () => {
+  const contact = {
+    mainImage:
+      'https://cse.snu.ac.kr/sites/default/files/styles/scale-width-220/public/node--contact/301.jpg?itok=zbUgVCfd',
+    address: '08826 서울특별시 관악구 관악로 1 (301동 316호)',
+    location: `서울대학교 관악 301동[신공학관1]`,
+    staffUrl: 'https://cse.snu.ac.kr/contact-us',
+    fax: '(02) 886-7589',
+    time: '평일 9:00 ~ 18:00 / 휴게시간: 12:00 ~ 13:00',
+    emailList: [
+      { name: '학부/대학원 입학 문의', email: 'ipsi@cse.snu.ac.kr' },
+      { name: '외국인(글로벌전형) 입학 문의', email: 'admission@cse.snu.ac.kr' },
+      { name: '채용정보 게시요청', email: 'bulletin@cse.snu.ac.kr' },
+    ],
+  };
+  return contact;
+};

--- a/apis/facilities.ts
+++ b/apis/facilities.ts
@@ -1,9 +1,9 @@
-import { GETFacilitiesPostsResponse } from '@/types/post';
+import { FacilitiesResponse } from '@/types/facilities';
 
 import { getRequest } from '.';
 
-export const getFacilitiesPosts = () =>
-  getRequest('/facilities') as Promise<GETFacilitiesPostsResponse>;
+const facilitiesPath = '/facilities';
+export const getFacilitiesPosts = () => getRequest(facilitiesPath) as Promise<FacilitiesResponse>;
 
 export const getMockFacilitiesPosts: typeof getFacilitiesPosts = async () => {
   const facilitiesList = Array.from({ length: 8 }, (_, index) => ({

--- a/apis/seminar.ts
+++ b/apis/seminar.ts
@@ -4,11 +4,13 @@ import { GETSeminarPostsResponse, SeminarPostResponse } from '@/types/post';
 
 import { getRequest } from '.';
 
+const seminarPath = '/seminar';
+
 export const getSeminarPosts = (params: PostSearchQueryParams) =>
-  getRequest('/seminar', params) as Promise<GETSeminarPostsResponse>;
+  getRequest(seminarPath, params) as Promise<GETSeminarPostsResponse>;
 
 export const getSeminarPost = (id: number) =>
-  getRequest(`/seminar/${id}`) as Promise<SeminarPostResponse>;
+  getRequest(`/${seminarPath}/${id}`) as Promise<SeminarPostResponse>;
 
 export const getMockSeminarPosts: typeof getSeminarPosts = async (
   params: PostSearchQueryParams,

--- a/app/about/contact/page.tsx
+++ b/app/about/contact/page.tsx
@@ -1,0 +1,67 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { getMockContact } from '@/apis/contact';
+
+import PageLayout from '@/components/layout/PageLayout';
+
+export default async function ContactPage() {
+  const contact = await getMockContactData();
+  return (
+    <PageLayout titleSize="text-2xl">
+      <div className="flow-root break-all font-noto text-neutral-700">
+        <div className="relative float-right w-60 h-[360px] ml-5">
+          <Image
+            src={contact.mainImage}
+            alt="대표 이미지"
+            priority
+            fill
+            className="object-cover"
+            sizes="240px"
+          />
+        </div>
+        <div className="mb-10">
+          <h3 className="font-bold text-base leading-8">서울대학교 공과대학 컴퓨터공학부</h3>
+          <p className="font-normal text-sm leading-[26px]">{contact.address}</p>
+        </div>
+        <div className="mb-10 w-[528px]">
+          <h3 className="font-bold text-base leading-8 pb-1 border-b-[1px] border-b-neutral-200">
+            학부 행정실
+          </h3>
+          <div className="font-normal text-sm leading-[26px] pt-1">
+            <p>위치 : {contact.location}</p>
+            <p>
+              전화 :
+              <Link href={contact.staffUrl} className="text-link hover:underline ml-1">
+                행정직원
+              </Link>
+              에 문의
+            </p>
+            <p>팩스 : {contact.fax}</p>
+            <p>근무 시간 : {contact.time}</p>
+          </div>
+        </div>
+        <div className="mb-10 w-[528px]">
+          <h3 className="font-bold text-base leading-8 pb-1 border-b-[1px] border-b-neutral-200">
+            이메일
+          </h3>
+          <div className="pt-1">
+            {contact.emailList.map((email, i) => (
+              <div className="flex flex-row font-normal text-sm leading-[26px]" key={i}>
+                <p>{email.name}:</p>
+                <Link href={`mailto:${email.email}`} className="text-link hover:underline ml-1">
+                  {email.email}
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </PageLayout>
+  );
+}
+
+async function getMockContactData() {
+  const contact = getMockContact();
+  return contact;
+}

--- a/app/about/contact/page.tsx
+++ b/app/about/contact/page.tsx
@@ -6,13 +6,13 @@ import { getMockContact } from '@/apis/contact';
 import PageLayout from '@/components/layout/PageLayout';
 
 export default async function ContactPage() {
-  const contact = await getMockContactData();
+  const { mainImage, address, location, staffUrl, fax, time, emailList } = await getMockContact();
   return (
     <PageLayout titleSize="text-2xl">
       <div className="flow-root break-all font-noto text-neutral-700">
         <div className="relative float-right w-60 h-[360px] ml-5">
           <Image
-            src={contact.mainImage}
+            src={mainImage}
             alt="대표 이미지"
             priority
             fill
@@ -22,23 +22,23 @@ export default async function ContactPage() {
         </div>
         <div className="mb-10">
           <h3 className="font-bold text-base leading-8">서울대학교 공과대학 컴퓨터공학부</h3>
-          <p className="font-normal text-sm leading-[26px]">{contact.address}</p>
+          <p className="font-normal text-sm leading-[26px]">{address}</p>
         </div>
         <div className="mb-10 w-[528px]">
           <h3 className="font-bold text-base leading-8 pb-1 border-b-[1px] border-b-neutral-200">
             학부 행정실
           </h3>
           <div className="font-normal text-sm leading-[26px] pt-1">
-            <p>위치 : {contact.location}</p>
+            <p>위치 : {location}</p>
             <p>
               전화 :
-              <Link href={contact.staffUrl} className="text-link hover:underline ml-1">
+              <Link href={staffUrl} className="text-link hover:underline ml-1">
                 행정직원
               </Link>
               에 문의
             </p>
-            <p>팩스 : {contact.fax}</p>
-            <p>근무 시간 : {contact.time}</p>
+            <p>팩스 : {fax}</p>
+            <p>근무 시간 : {time}</p>
           </div>
         </div>
         <div className="mb-10 w-[528px]">
@@ -46,7 +46,7 @@ export default async function ContactPage() {
             이메일
           </h3>
           <div className="pt-1">
-            {contact.emailList.map((email, i) => (
+            {emailList.map((email, i) => (
               <div className="flex flex-row font-normal text-sm leading-[26px]" key={i}>
                 <p>{email.name}:</p>
                 <Link href={`mailto:${email.email}`} className="text-link hover:underline ml-1">
@@ -59,9 +59,4 @@ export default async function ContactPage() {
       </div>
     </PageLayout>
   );
-}
-
-async function getMockContactData() {
-  const contact = getMockContact();
-  return contact;
 }

--- a/types/contact.ts
+++ b/types/contact.ts
@@ -1,0 +1,12 @@
+export interface ContactResponse {
+  mainImage: string;
+  address: string;
+  location: string;
+  staffUrl: string;
+  fax: string;
+  time: string;
+  emailList: {
+    name: string;
+    email: string;
+  }[];
+}

--- a/types/facilities.ts
+++ b/types/facilities.ts
@@ -1,0 +1,8 @@
+export interface FacilitiesResponse {
+  facilitiesList: {
+    name: string;
+    description: string;
+    location: string;
+    imageURL: string;
+  }[];
+}

--- a/types/post.ts
+++ b/types/post.ts
@@ -101,12 +101,3 @@ export interface SeminarPostResponse extends PostResponse {
   imageURL: string;
   isLast?: boolean;
 }
-
-export interface GETFacilitiesPostsResponse {
-  facilitiesList: {
-    name: string;
-    description: string;
-    location: string;
-    imageURL: string;
-  }[];
-}


### PR DESCRIPTION
## 연락처 페이지
<img width="500" alt="스크린샷 2023-08-19 오전 5 15 49" src="https://github.com/wafflestudio/csereal-web/assets/102405705/25901d06-705e-46aa-b4f8-29f85934d00a">

## 참고사항
- 현재 연락처 페이지의 세부 사항들을 따로 받는 형태라 HtmlViewer로 하지 않고 각각의 데이터들을 받아놓는 형식으로 하였습니다.
- 크게 특별한 점은 없어서 간단하게 리뷰 후에 머지해도 괜찮을 것 같습니다.