### PR TITLE
💄 HTMLViewer에 suneditor 스타일 적용

### DIFF
--- a/components/common/HTMLViewer.tsx
+++ b/components/common/HTMLViewer.tsx
@@ -1,6 +1,7 @@
 import DOMPurify from 'isomorphic-dompurify';
 import Image from 'next/image';
 import { ReactNode } from 'react';
+import 'suneditor/dist/css/suneditor.min.css';
 
 interface TopRightImage {
   type: 'image';
@@ -30,17 +31,7 @@ export default function HTMLViewer({ htmlContent, topRightContent, margin = '' }
     <div className={`flow-root ${margin}`}>
       {topRightContent?.type === 'image' && <TopRightImageContent {...topRightContent} />}
       {topRightContent?.type === 'component' && <TopRightComponent {...topRightContent} />}
-      <div
-        className={`
-        text-sm font-noto font-regular leading-loose 
-        [&_a]:text-link hover:[&_a]:underline
-        [&_li]:list-disc [&_li]:list-inside 
-        [&_p]:mb-4 
-        [&_td]:border-[1px] [&_td]:border-neutral-300
-        [&_img]:inline
-        `}
-        dangerouslySetInnerHTML={{ __html: sanitizedHTML }}
-      />
+      <div className="sun-editor-editable" dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />
     </div>
   );
 }


### PR DESCRIPTION
Suneditor 리드미의 아래 내용을 참고하여 적용

> When you display a document created by suneditor
You need to include "src/assets/css/suneditor-contents.css" or "dist/css/suneditor.min.css" file.
Then add "sun-editor-editable" to the class name of the Tag element that displays the content.
If you are using RTL mode, you also need to add "se-rtl".
In "suneditor-contents.css", you can define the style of all the tags created in suneditor.

community/news/create/page.tsx를 아래 내용으로 수정하면 '게시하기' 버튼을 누를때마다 하단에 HTMLViewer의 내용이 업데이트됨. 

```tsx
'use client';

import { useState } from 'react';

import HTMLViewer from '@/components/common/HTMLViewer';
import PostEditor from '@/components/editor/PostEditor';
import { EditorContent } from '@/components/editor/PostEditorProp';
import PageLayout from '@/components/layout/pageLayout/PageLayout';

import { NewsTags } from '@/constants/tag';

export default function NewsCreatePage() {
  const [temp, setTemp] = useState('');
  const handleComplete = async (content: EditorContent) => {
    console.log(content.description);
    // throw new Error();
    setTemp(content.description);
  };

  return (
    <PageLayout title="새 소식 쓰기" titleType="small">
      <PostEditor
        tags={NewsTags}
        showMainImage
        showIsSlide
        actions={{
          type: 'CREATE',
          onComplete: handleComplete,
        }}
      />
      <HTMLViewer htmlContent={temp} />
    </PageLayout>
  );
}

```