### PR TITLE
🐛 연구실 페이지 클라이언트 컴포넌트 에러 해결

### DIFF
--- a/app/[locale]/research/labs/ResearchLabDetails.tsx
+++ b/app/[locale]/research/labs/ResearchLabDetails.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Link } from '@/navigation';
 import PentagonLong from '@/public/image/pentagon_long.svg';
 import PentagonShort from '@/public/image/pentagon_short.svg';

--- a/app/[locale]/research/labs/[id]/ResearchLabDetails.tsx
+++ b/app/[locale]/research/labs/[id]/ResearchLabDetails.tsx
@@ -13,7 +13,7 @@ import { getPath } from '@/utils/page';
 import { replaceSpaceWithDash } from '@/utils/replaceCharacter';
 import { researchGroups } from '@/utils/segmentNode';
 
-import ResearchLabInfo from './ResesarchLabInfo';
+import ResearchLabInfo from '../ResesarchLabInfo';
 
 export default function ResearchLabDetails({ lab }: { lab: ResearchLab }) {
   const { screenType } = useResponsive();

--- a/app/[locale]/research/labs/[id]/page.tsx
+++ b/app/[locale]/research/labs/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { getResearchLab } from '@/apis/research';
 
-import ResearchLabDetails from '@/app/[locale]/research/labs/ResearchLabDetails';
+import ResearchLabDetails from '@/app/[locale]/research/labs/[id]/ResearchLabDetails';
 
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 


### PR DESCRIPTION
- `useReponsive` 훅 사용한 파일이 서버 컴포넌트로 되어 있어서 발생했던 에러 해결