### PR TITLE
📱 통합검색 반응형

### DIFF
--- a/app/[locale]/research/labs/[id]/ResesarchLabInfo.tsx
+++ b/app/[locale]/research/labs/[id]/ResesarchLabInfo.tsx
@@ -11,7 +11,6 @@ import { ResearchLab } from '@/types/research';
 import { getPath } from '@/utils/page';
 import { faculty } from '@/utils/segmentNode';
 
-// drop-shadow(0px 0px 10px rgba(0,0,0,0.15))/
 export default function ResearchLabInfo({ lab }: { lab: ResearchLab }) {
   const dropShadow = 'drop-shadow(1px 2px 2px rgba(0,0,0,0.25))';
   const triangleLength = 2.5; // 20px

--- a/app/[locale]/research/labs/[id]/ResesarchLabInfo.tsx
+++ b/app/[locale]/research/labs/[id]/ResesarchLabInfo.tsx
@@ -11,8 +11,9 @@ import { ResearchLab } from '@/types/research';
 import { getPath } from '@/utils/page';
 import { faculty } from '@/utils/segmentNode';
 
+// drop-shadow(0px 0px 10px rgba(0,0,0,0.15))/
 export default function ResearchLabInfo({ lab }: { lab: ResearchLab }) {
-  const dropShadow = 'drop-shadow(1px 2px 2px rgba(0,0,0,0.25)';
+  const dropShadow = 'drop-shadow(1px 2px 2px rgba(0,0,0,0.25))';
   const triangleLength = 2.5; // 20px
   const radius = 0.125; // 2px
 

--- a/app/[locale]/search/CommunitySection.tsx
+++ b/app/[locale]/search/CommunitySection.tsx
@@ -98,7 +98,10 @@ const CommunitySubSection = ({
   return (
     <>
       <CircleTitle title={title} size={size} />
-      <div className="ml-5 mr-10 mt-8 flex flex-col gap-7" id={`nav_${title.replace(' ', '_')}`}>
+      <div
+        className="mx-5 mt-8 flex flex-col gap-[1.875rem] sm:mr-10 sm:gap-7"
+        id={`nav_${title.replace(' ', '_')}`}
+      >
         {children}
       </div>
       <MoreResultLink href={href} />

--- a/app/[locale]/search/MemberSection.tsx
+++ b/app/[locale]/search/MemberSection.tsx
@@ -20,7 +20,7 @@ export default async function MemberSection({ member }: { member: MemberSearchRe
       {professorList.length !== 0 && (
         <>
           <CircleTitle title="교수진" />
-          <div className="ml-5 mt-7 flex gap-12">
+          <div className="ml-5 mt-7 flex flex-wrap gap-10 sm:gap-12">
             {professorList.slice(0, 3).map((result) => {
               return <MemberCell key={result.id} {...result} />;
             })}
@@ -31,7 +31,7 @@ export default async function MemberSection({ member }: { member: MemberSearchRe
       {staffList.length !== 0 && (
         <>
           <CircleTitle title="행정직원" />
-          <div className="ml-5 mt-7 flex gap-12">
+          <div className="ml-5 mt-7 flex flex-wrap gap-10 sm:gap-12">
             {staffList.slice(0, 3).map((result) => {
               return <MemberCell key={result.id} {...result} />;
             })}

--- a/app/[locale]/search/helper/BasicRow.tsx
+++ b/app/[locale]/search/helper/BasicRow.tsx
@@ -16,7 +16,7 @@ type BasicRowProps = {
 
 export default function BasicRow({ href, title, node, ...description }: BasicRowProps) {
   return (
-    <div className="ml-5 flex flex-col gap-[0.63rem]">
+    <div className="ml-5 flex flex-col gap-2 sm:gap-2.5">
       <Link className="text-base font-bold hover:underline" href={href}>
         {title}
       </Link>

--- a/app/[locale]/search/helper/NewsRow.tsx
+++ b/app/[locale]/search/helper/NewsRow.tsx
@@ -30,8 +30,8 @@ export default function NewsRow({
   });
 
   return (
-    <article className="flex gap-6">
-      <Link href={href} className="relative flex aspect-[4/3] h-[9.375rem]">
+    <article className="flex flex-col gap-5 sm:flex-row sm:gap-6">
+      <Link href={href} className="relative flex aspect-[4/3] sm:h-[9.375rem]">
         <ImageWithFallback
           alt="포스트 대표 이미지"
           src={imageURL}
@@ -40,7 +40,11 @@ export default function NewsRow({
           sizes="12.5rem"
         />
       </Link>
-      <div className="mr-8 flex flex-col justify-between">
+      <div className="flex flex-col justify-between gap-2.5 sm:gap-0">
+        <time className="whitespace-nowrap text-sm leading-[26px] text-neutral-800 sm:order-last">
+          {dateStr}
+        </time>
+
         <div className="flex flex-col items-start">
           <Link href={href} className="hover:underline">
             <h3 className="mb-2.5 text-base font-bold">{title}</h3>
@@ -59,8 +63,6 @@ export default function NewsRow({
             </p>
           </Link>
         </div>
-
-        <time className="whitespace-nowrap text-sm leading-[26px] text-neutral-800">{dateStr}</time>
       </div>
     </article>
   );

--- a/app/[locale]/search/helper/Section.tsx
+++ b/app/[locale]/search/helper/Section.tsx
@@ -16,7 +16,7 @@ export default function Section({
   return (
     <div className="flex flex-col" id={`nav_${title.replace(' ', '_')}`}>
       <div className="mb-8 flex">
-        <h3 className="inline border-b-2 border-neutral-200 pb-[.59rem] pl-[.63rem] pr-[.63rem] text-[1.25rem] font-semibold leading-loose text-neutral-950">
+        <h3 className="inline border-b-2 border-neutral-200 px-2.5 pb-2 text-[1.25rem] font-semibold leading-loose text-neutral-950">
           {t(title)}({size})
         </h3>
         <div className="flex h-5 self-end">

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -47,7 +47,7 @@ export default async function SearchPage({
 
   return (
     <SearchPageLayout node={node}>
-      <p className="mb-14 ml-[0.62rem]  text-md text-neutral-500">{total}개의 검색결과</p>
+      <p className="mb-11 ml-3 text-md  text-neutral-500 sm:mb-14">{total}개의 검색결과</p>
       <div className="flex grow flex-col gap-20">
         {sectionContent[0] && <AboutSection about={sectionContent[0]} />}
         {sectionContent[1] && (

--- a/components/common/RangeBolded.tsx
+++ b/components/common/RangeBolded.tsx
@@ -8,7 +8,7 @@ export default function RangeBolded({
   boldEndIndex: number;
 }) {
   return (
-    <p className="truncate-multi sm:truncate-single text-md font-normal text-neutral-700">
+    <p className="truncate-multi sm:truncate-single text-md font-normal leading-normal text-neutral-700">
       {partialDescription.slice(0, boldStartIndex)}
       <span className="font-semibold text-neutral-950">
         {partialDescription.slice(boldStartIndex, boldEndIndex)}

--- a/components/common/RangeBolded.tsx
+++ b/components/common/RangeBolded.tsx
@@ -8,7 +8,7 @@ export default function RangeBolded({
   boldEndIndex: number;
 }) {
   return (
-    <p className="truncate text-md font-normal text-neutral-700">
+    <p className="truncate-multi sm:truncate-single text-md font-normal text-neutral-700">
       {partialDescription.slice(0, boldStartIndex)}
       <span className="font-semibold text-neutral-950">
         {partialDescription.slice(boldStartIndex, boldEndIndex)}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -101,4 +101,22 @@
     transition: background-color 5000s ease-in-out 0s;
     caret-color: #262626;
   }
+
+  .truncate-multi {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  .truncate-single {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+  }
 }


### PR DESCRIPTION
- 검색 결과 본문 말줄임 클래스 추가
  - tailwind에서 제공하는 `truncate`를 사용하려고 했으나, 기본 2줄 말줄임 적용 시에 활성화되는 다른 클래스들도 직접 리셋해주기 위해 한 줄 말줄임도 `truncate-single` 클래스 새롭게 추가하여 사용
- 새소식, 교수진 레이아웃 정도만 수정
- 기타 gap 등 미세 조정 