### PR TITLE
🐛 명예교수가 교수진 개별 페이지에 보이는 버그 수정

### DIFF
--- a/app/[locale]/people/faculty/[id]/page.tsx
+++ b/app/[locale]/people/faculty/[id]/page.tsx
@@ -1,3 +1,5 @@
+import { notFound } from 'next/navigation';
+
 import { Link } from '@/navigation';
 
 import { getFaculty } from '@/apis/people';
@@ -17,6 +19,7 @@ const labUrl = getPath(researchLabs);
 
 export default async function FacultyMemberPage({ params }: { params: { id: number } }) {
   const faculty = await getFaculty(params.id);
+  if (faculty.status !== 'ACTIVE') notFound();
 
   return (
     <PageLayout title={<PageTitle {...faculty} />} titleType="big" titleMargin="mb-9">


### PR DESCRIPTION
- `/faculty`에서 명예교수를 불러왔을 때는 404 페이지로 이동