### PR TITLE
♻️ 선택형 쿼리 영어로 올라가도록 변경

### DIFF
--- a/app/[locale]/about/directions/page.tsx
+++ b/app/[locale]/about/directions/page.tsx
@@ -42,7 +42,7 @@ export default async function DirectionsPage({ searchParams }: DirectionsPagePro
         <LocationMap />
       </div>
       <SelectionList
-        names={directionList.map((d) => d.name)}
+        names={directionList.map((d) => ({ ko: d.name }))}
         selectedItemName={selectedDirection?.name ?? ''}
         rootPath={directionsPath}
       />

--- a/app/[locale]/about/directions/page.tsx
+++ b/app/[locale]/about/directions/page.tsx
@@ -43,7 +43,7 @@ export default async function DirectionsPage({ searchParams }: DirectionsPagePro
       </div>
       <SelectionList
         names={directionList.map((d) => ({ ko: d.name }))}
-        selectedItemName={selectedDirection?.name ?? ''}
+        selectedItemNameKo={selectedDirection?.name ?? ''}
         rootPath={directionsPath}
       />
       {selectedDirection ? (

--- a/app/[locale]/about/directions/page.tsx
+++ b/app/[locale]/about/directions/page.tsx
@@ -44,7 +44,7 @@ export default async function DirectionsPage({ searchParams }: DirectionsPagePro
       <SelectionList
         names={directionList.map((d) => d.name)}
         selectedItemName={selectedDirection?.name ?? ''}
-        path={directionsPath}
+        rootPath={directionsPath}
       />
       {selectedDirection ? (
         <DirectionsDetails direction={selectedDirection} />

--- a/app/[locale]/about/student-clubs/page.tsx
+++ b/app/[locale]/about/student-clubs/page.tsx
@@ -34,9 +34,9 @@ export default async function StudentClubsPage({ searchParams }: StudentClubsPag
   return (
     <PageLayout titleType="big" bodyStyle={{ paddingTop: 0 }}>
       <SelectionList
-        names={clubs.map((club) => club.name)}
+        names={clubs.map((club) => ({ ko: club.name, en: club.engName }))}
         selectedItemName={selectedClub?.name ?? ''}
-        path={clubPath}
+        rootPath={clubPath}
       />
       {selectedClub ? (
         <ClubDetails club={selectedClub} />

--- a/app/[locale]/about/student-clubs/page.tsx
+++ b/app/[locale]/about/student-clubs/page.tsx
@@ -35,7 +35,7 @@ export default async function StudentClubsPage({ searchParams }: StudentClubsPag
     <PageLayout titleType="big" bodyStyle={{ paddingTop: 0 }}>
       <SelectionList
         names={clubs.map((club) => ({ ko: club.name, en: club.engName }))}
-        selectedItemName={selectedClub?.name ?? ''}
+        selectedItemNameKo={selectedClub?.name ?? ''}
         rootPath={clubPath}
       />
       {selectedClub ? (

--- a/app/[locale]/admin/page.tsx
+++ b/app/[locale]/admin/page.tsx
@@ -32,7 +32,7 @@ export default async function AdminPage({ searchParams: { selected, page } }: Ad
         <SelectionList
           names={['슬라이드쇼 관리', '중요 안내 관리']}
           selectedItemName={selectedMenu}
-          path={adminPath}
+          rootPath={adminPath}
           listGridColumnClass="grid-cols-[200px_220px]"
         />
         <PageContent selected={selectedMenu} pageNum={pageNum} />

--- a/app/[locale]/admin/page.tsx
+++ b/app/[locale]/admin/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminPage({ searchParams: { selected, page } }: Ad
     <PageLayout title="관리자 메뉴" titleType="big" titleMargin="mb-9">
       <LoginVisible staff fallback={<p>관리자만 사용할 수 있는 페이지입니다.</p>}>
         <SelectionList
-          names={['슬라이드쇼 관리', '중요 안내 관리']}
+          names={[{ ko: '슬라이드쇼 관리' }, { ko: '중요 안내 관리' }]}
           selectedItemName={selectedMenu}
           rootPath={adminPath}
           listGridColumnClass="grid-cols-[200px_220px]"

--- a/app/[locale]/admin/page.tsx
+++ b/app/[locale]/admin/page.tsx
@@ -31,7 +31,7 @@ export default async function AdminPage({ searchParams: { selected, page } }: Ad
       <LoginVisible staff fallback={<p>관리자만 사용할 수 있는 페이지입니다.</p>}>
         <SelectionList
           names={[{ ko: '슬라이드쇼 관리' }, { ko: '중요 안내 관리' }]}
-          selectedItemName={selectedMenu}
+          selectedItemNameKo={selectedMenu}
           rootPath={adminPath}
           listGridColumnClass="grid-cols-[200px_220px]"
         />

--- a/app/[locale]/research/centers/page.tsx
+++ b/app/[locale]/research/centers/page.tsx
@@ -31,7 +31,7 @@ export default async function ResearchCentersPage({
       <SelectionList
         names={centers.map((center) => center.name)}
         selectedItemName={selectedCenter?.name ?? ''}
-        path={researchCentersPath}
+        rootPath={researchCentersPath}
         listGridColumnClass="lg:grid-cols-[repeat(auto-fit,minmax(_200px,_auto))]"
       />
       {selectedCenter ? (

--- a/app/[locale]/research/centers/page.tsx
+++ b/app/[locale]/research/centers/page.tsx
@@ -30,7 +30,7 @@ export default async function ResearchCentersPage({
     <PageLayout titleType="big" bodyStyle={{ paddingTop: 0 }}>
       <SelectionList
         names={centers.map((center) => ({ ko: center.name }))}
-        selectedItemName={selectedCenter?.name ?? ''}
+        selectedItemNameKo={selectedCenter?.name ?? ''}
         rootPath={researchCentersPath}
         listGridColumnClass="lg:grid-cols-[repeat(auto-fit,minmax(_200px,_auto))]"
       />

--- a/app/[locale]/research/centers/page.tsx
+++ b/app/[locale]/research/centers/page.tsx
@@ -29,7 +29,7 @@ export default async function ResearchCentersPage({
   return (
     <PageLayout titleType="big" bodyStyle={{ paddingTop: 0 }}>
       <SelectionList
-        names={centers.map((center) => center.name)}
+        names={centers.map((center) => ({ ko: center.name }))}
         selectedItemName={selectedCenter?.name ?? ''}
         rootPath={researchCentersPath}
         listGridColumnClass="lg:grid-cols-[repeat(auto-fit,minmax(_200px,_auto))]"

--- a/app/[locale]/research/groups/page.tsx
+++ b/app/[locale]/research/groups/page.tsx
@@ -31,7 +31,7 @@ export default async function ResearchGroupsPage({
         <SelectionList
           names={groups.map((group) => group.name)}
           selectedItemName={selectedGroup?.name ?? ''}
-          path={researchGroupsPath}
+          rootPath={researchGroupsPath}
           listGridColumnClass="lg:grid-cols-[repeat(auto-fit,minmax(_236px,_auto))]"
         />
       </div>

--- a/app/[locale]/research/groups/page.tsx
+++ b/app/[locale]/research/groups/page.tsx
@@ -29,7 +29,7 @@ export default async function ResearchGroupsPage({
       {/* TODO: 외부 div 스타일링 SelectionList에서 표현 */}
       <div className="px-7 sm:pl-[100px] sm:pr-[320px]">
         <SelectionList
-          names={groups.map((group) => group.name)}
+          names={groups.map((group) => ({ ko: group.name }))}
           selectedItemName={selectedGroup?.name ?? ''}
           rootPath={researchGroupsPath}
           listGridColumnClass="lg:grid-cols-[repeat(auto-fit,minmax(_236px,_auto))]"

--- a/app/[locale]/research/groups/page.tsx
+++ b/app/[locale]/research/groups/page.tsx
@@ -30,7 +30,7 @@ export default async function ResearchGroupsPage({
       <div className="px-7 sm:pl-[100px] sm:pr-[320px]">
         <SelectionList
           names={groups.map((group) => ({ ko: group.name }))}
-          selectedItemName={selectedGroup?.name ?? ''}
+          selectedItemNameKo={selectedGroup?.name ?? ''}
           rootPath={researchGroupsPath}
           listGridColumnClass="lg:grid-cols-[repeat(auto-fit,minmax(_236px,_auto))]"
         />

--- a/app/[locale]/reservations/introduction/page.tsx
+++ b/app/[locale]/reservations/introduction/page.tsx
@@ -32,7 +32,7 @@ export default function ReservationIntroductionPage({
   return (
     <PageLayout titleType="big" bodyStyle={{ paddingTop: 0, paddingBottom: 300 }}>
       <SelectionList
-        names={names}
+        names={names.map((name) => ({ ko: name }))}
         selectedItemName={itemName}
         rootPath={path}
         listGridColumnClass="lg:grid-cols-[repeat(auto-fit,_minmax(200px,_auto))]"

--- a/app/[locale]/reservations/introduction/page.tsx
+++ b/app/[locale]/reservations/introduction/page.tsx
@@ -34,7 +34,7 @@ export default function ReservationIntroductionPage({
       <SelectionList
         names={names}
         selectedItemName={itemName}
-        path={path}
+        rootPath={path}
         listGridColumnClass="lg:grid-cols-[repeat(auto-fit,_minmax(200px,_auto))]"
       />
       <SelectionTitle animationKey={itemName}>{itemName}</SelectionTitle>

--- a/app/[locale]/reservations/introduction/page.tsx
+++ b/app/[locale]/reservations/introduction/page.tsx
@@ -25,15 +25,15 @@ export default function ReservationIntroductionPage({
 }: {
   searchParams: { selected?: string };
 }) {
-  const selected = (searchParams.selected ||= names[0]);
+  const selected = (searchParams.selected ||= names[0].ko);
   const temp = replaceDashWithSpace(selected);
-  const itemName = isSearchParamValid(temp) ? temp : names[0];
+  const itemName = isSearchParamValid(temp) ? temp : names[0].ko;
 
   return (
     <PageLayout titleType="big" bodyStyle={{ paddingTop: 0, paddingBottom: 300 }}>
       <SelectionList
-        names={names.map((name) => ({ ko: name }))}
-        selectedItemName={itemName}
+        names={names}
+        selectedItemNameKo={itemName}
         rootPath={path}
         listGridColumnClass="lg:grid-cols-[repeat(auto-fit,_minmax(200px,_auto))]"
       />
@@ -43,10 +43,14 @@ export default function ReservationIntroductionPage({
   );
 }
 
-const names = ['세미나실 예약', '실습실 예약', '공과대학 강의실 예약'] as const;
+const names = [
+  { ko: '세미나실 예약' },
+  { ko: '실습실 예약' },
+  { ko: '공과대학 강의실 예약' },
+] as const;
 
-const isSearchParamValid = (searchParam: string): searchParam is (typeof names)[number] => {
-  return names.findIndex((x) => x === searchParam) !== -1;
+const isSearchParamValid = (searchParam: string): searchParam is (typeof names)[number]['ko'] => {
+  return names.findIndex((x) => x.ko === searchParam) !== -1;
 };
 
 const htmlContents = {

--- a/components/common/selection/SelectionList.tsx
+++ b/components/common/selection/SelectionList.tsx
@@ -9,9 +9,9 @@ import { COLOR_THEME } from '@/constants/color';
 import { replaceSpaceWithDash } from '@/utils/string';
 
 interface SelectionListProps {
-  names: readonly string[];
+  names: readonly { ko: string; en?: string }[] | readonly string[];
   selectedItemName: string;
-  path: string;
+  rootPath: string;
   /**
    * 반응형 고려해서 그리드 스타일 넣어줘야 함
    * 아래는 예시
@@ -23,7 +23,7 @@ interface SelectionListProps {
 export default function SelectionList({
   names,
   selectedItemName,
-  path,
+  rootPath,
   listGridColumnClass = 'lg:grid-cols-[repeat(auto-fit,_minmax(200px,_auto))]',
   listItemPadding = '',
 }: SelectionListProps) {
@@ -31,15 +31,25 @@ export default function SelectionList({
 
   return (
     <ul className={`grid ${gridStyle} mb-6 gap-3 pt-7 sm:mb-9 sm:pt-11`}>
-      {names.map((name) => (
-        <SelectionItem
-          key={name}
-          path={path}
-          name={name}
-          isSelected={name === selectedItemName}
-          padding={listItemPadding}
-        />
-      ))}
+      {names.map((name) =>
+        typeof name === 'string' ? (
+          <SelectionItem
+            key={name}
+            href={`${rootPath}?selected=${replaceSpaceWithDash(name)}`}
+            name={name}
+            isSelected={name === selectedItemName}
+            padding={listItemPadding}
+          />
+        ) : (
+          <SelectionItem
+            key={name.ko}
+            href={`${rootPath}?selected=${replaceSpaceWithDash(name.en || name.ko)}`}
+            name={name.ko}
+            isSelected={name.ko === selectedItemName}
+            padding={listItemPadding}
+          />
+        ),
+      )}
     </ul>
   );
 }
@@ -47,11 +57,11 @@ export default function SelectionList({
 interface SelectionItemProps {
   name: string;
   isSelected: boolean;
-  path: string;
+  href: string;
   padding: string;
 }
 
-function SelectionItem({ name, isSelected, path, padding }: SelectionItemProps) {
+function SelectionItem({ name, isSelected, href: href, padding }: SelectionItemProps) {
   const itemCommonStyle = `flex items-center justify-center w-full h-10 py-3 text-center text-[11px] sm:text-sm lg:text-md tracking-wide ${padding}`;
   const triangleLength = 1.25; // 20px
   const radius = 0.125; // 2px
@@ -79,7 +89,7 @@ function SelectionItem({ name, isSelected, path, padding }: SelectionItemProps) 
           width="w-full"
         >
           <Link
-            href={`${path}?selected=${replaceSpaceWithDash(name)}`}
+            href={href}
             className={`${itemCommonStyle} text-neutral-500 transition-all duration-300 hover:text-neutral-800`}
             scroll={false}
           >

--- a/components/common/selection/SelectionList.tsx
+++ b/components/common/selection/SelectionList.tsx
@@ -61,7 +61,7 @@ interface SelectionItemProps {
   padding: string;
 }
 
-function SelectionItem({ name, isSelected, href: href, padding }: SelectionItemProps) {
+function SelectionItem({ name, isSelected, href, padding }: SelectionItemProps) {
   const itemCommonStyle = `flex items-center justify-center w-full h-10 py-3 text-center text-[11px] sm:text-sm lg:text-md tracking-wide ${padding}`;
   const triangleLength = 1.25; // 20px
   const radius = 0.125; // 2px

--- a/components/common/selection/SelectionList.tsx
+++ b/components/common/selection/SelectionList.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useLocale } from 'next-intl';
+
 import { Link } from '@/navigation';
 
 import CornerFoldedRectangle from '@/components/common/CornerFoldedRectangle/index';
@@ -10,7 +12,7 @@ import { replaceSpaceWithDash } from '@/utils/string';
 
 interface SelectionListProps {
   names: readonly { ko: string; en?: string }[];
-  selectedItemName: string;
+  selectedItemNameKo: string;
   rootPath: string;
   /**
    * 반응형 고려해서 그리드 스타일 넣어줘야 함
@@ -22,34 +24,26 @@ interface SelectionListProps {
 
 export default function SelectionList({
   names,
-  selectedItemName,
+  selectedItemNameKo,
   rootPath,
   listGridColumnClass = 'lg:grid-cols-[repeat(auto-fit,_minmax(200px,_auto))]',
   listItemPadding = '',
 }: SelectionListProps) {
+  const locale = useLocale() as 'ko' | 'en';
+
   const gridStyle = `grid-cols-[repeat(2,_1fr)] ${listGridColumnClass}`;
 
   return (
     <ul className={`grid ${gridStyle} mb-6 gap-3 pt-7 sm:mb-9 sm:pt-11`}>
-      {names.map((name) =>
-        typeof name === 'string' ? (
-          <SelectionItem
-            key={name}
-            href={`${rootPath}?selected=${replaceSpaceWithDash(name)}`}
-            name={name}
-            isSelected={name === selectedItemName}
-            padding={listItemPadding}
-          />
-        ) : (
-          <SelectionItem
-            key={name.ko}
-            href={`${rootPath}?selected=${replaceSpaceWithDash(name.en || name.ko)}`}
-            name={name.ko}
-            isSelected={name.ko === selectedItemName}
-            padding={listItemPadding}
-          />
-        ),
-      )}
+      {names.map((name) => (
+        <SelectionItem
+          key={name.ko}
+          href={`${rootPath}?selected=${replaceSpaceWithDash(name.en || name.ko)}`} // 주소는 영문명 우선
+          name={name[locale] ?? name.ko}
+          isSelected={name.ko === selectedItemNameKo}
+          padding={listItemPadding}
+        />
+      ))}
     </ul>
   );
 }

--- a/components/common/selection/SelectionList.tsx
+++ b/components/common/selection/SelectionList.tsx
@@ -9,7 +9,7 @@ import { COLOR_THEME } from '@/constants/color';
 import { replaceSpaceWithDash } from '@/utils/string';
 
 interface SelectionListProps {
-  names: readonly { ko: string; en?: string }[] | readonly string[];
+  names: readonly { ko: string; en?: string }[];
   selectedItemName: string;
   rootPath: string;
   /**

--- a/types/about.ts
+++ b/types/about.ts
@@ -45,6 +45,5 @@ export interface Contact {
 
 export interface Direction {
   name: string;
-  engName: string;
   description: string;
 }

--- a/utils/findSelectedItem.ts
+++ b/utils/findSelectedItem.ts
@@ -1,6 +1,6 @@
 import { replaceDashWithSpace } from './string';
 
-export const findSelectedItem = <T extends { name: string }>(
+export const findSelectedItem = <T extends { name: string; engName?: string }>(
   items: T[],
   dashedItemName?: string,
 ) => {
@@ -9,7 +9,7 @@ export const findSelectedItem = <T extends { name: string }>(
   if (dashedItemName === undefined) return defaultItem;
 
   const selectedName = replaceDashWithSpace(dashedItemName);
-  const item = items.find((item) => item.name === selectedName);
+  const item = items.find((item) => [item.name, item.engName].includes(selectedName));
 
   return item ?? defaultItem;
 };

--- a/utils/findSelectedItem.ts
+++ b/utils/findSelectedItem.ts
@@ -9,7 +9,7 @@ export const findSelectedItem = <T extends { name: string; engName?: string }>(
   if (dashedItemName === undefined) return defaultItem;
 
   const selectedName = replaceDashWithSpace(dashedItemName);
-  const item = items.find((item) => [item.name, item.engName].includes(selectedName));
+  const item = items.find((item) => item.name === selectedName || item.engName === selectedName);
 
   return item ?? defaultItem;
 };


### PR DESCRIPTION
- 영문명이 존재하는 경우 선택형 쿼리에서 영어 사용 (예시: 동아리 소개 페이지)
- `Direction` type에서 `engName` 삭제
  - 실제 백엔드 응답 중 해당 속성이 없음