### PR TITLE
🩹 소식 편집 페이지에서 서브내비 제거

### DIFF
--- a/app/[locale]/community/news/[id]/edit/EditNewsPageContent.tsx
+++ b/app/[locale]/community/news/[id]/edit/EditNewsPageContent.tsx
@@ -58,7 +58,7 @@ export default function EditNewsPageContent({ id, data }: { id: number; data: Ne
   };
 
   return (
-    <PageLayout title="새 소식 편집" titleType="big" titleMargin="mb-[2.25rem]">
+    <PageLayout title="새 소식 편집" titleType="big" titleMargin="mb-[2.25rem]" hideNavbar>
       <PostEditor
         tags={NEWS_TAGS}
         showMainImage

--- a/app/[locale]/community/news/create/page.tsx
+++ b/app/[locale]/community/news/create/page.tsx
@@ -28,7 +28,7 @@ export default function NewsCreatePage() {
   };
 
   return (
-    <PageLayout title="새 소식 작성" titleType="big" titleMargin="mb-[2.75rem]">
+    <PageLayout title="새 소식 작성" titleType="big" titleMargin="mb-[2.75rem]" hideNavbar>
       <PostEditor
         tags={NEWS_TAGS}
         showMainImage

--- a/app/[locale]/community/notice/[id]/edit/EditNoticePageContent.tsx
+++ b/app/[locale]/community/notice/[id]/edit/EditNoticePageContent.tsx
@@ -62,7 +62,7 @@ export default function EditNoticePageContent({ id, data }: { id: number; data: 
   };
 
   return (
-    <PageLayout title="공지사항 편집" titleType="big" titleMargin="mb-[2.25rem]">
+    <PageLayout title="공지사항 편집" titleType="big" titleMargin="mb-[2.25rem]" hideNavbar>
       <PostEditor
         tags={NOTICE_TAGS}
         showIsPinned

--- a/app/[locale]/community/notice/create/page.tsx
+++ b/app/[locale]/community/notice/create/page.tsx
@@ -30,7 +30,7 @@ export default function NoticeCreatePage() {
   };
 
   return (
-    <PageLayout title="공지사항 작성" titleType="big" titleMargin="mb-[2.75rem]">
+    <PageLayout title="공지사항 작성" titleType="big" titleMargin="mb-[2.75rem]" hideNavbar>
       <PostEditor
         tags={NOTICE_TAGS}
         showIsPinned

--- a/app/[locale]/community/seminar/[id]/edit/EditSeminarPageContent.tsx
+++ b/app/[locale]/community/seminar/[id]/edit/EditSeminarPageContent.tsx
@@ -60,7 +60,7 @@ export default function EditSeminarPageContent({ id, data }: { id: number; data:
   };
 
   return (
-    <PageLayout title="세미나 편집" titleType="big" titleMargin="mb-[2.25rem]">
+    <PageLayout title="세미나 편집" titleType="big" titleMargin="mb-[2.25rem]" hideNavbar>
       <SeminarEditor
         actions={{
           type: 'EDIT',

--- a/app/[locale]/community/seminar/create/page.tsx
+++ b/app/[locale]/community/seminar/create/page.tsx
@@ -28,7 +28,7 @@ export default function SeminarCreatePage() {
   };
 
   return (
-    <PageLayout title="세미나 작성" titleType="big" titleMargin="mb-[2.25rem]">
+    <PageLayout title="세미나 작성" titleType="big" titleMargin="mb-[2.25rem]" hideNavbar>
       <SeminarEditor
         actions={{
           type: 'CREATE',

--- a/components/layout/pageLayout/PageLayout.tsx
+++ b/components/layout/pageLayout/PageLayout.tsx
@@ -38,7 +38,7 @@ export default function PageLayout({
   titleType,
   titleMargin = 'mb-6 sm:mb-11',
   bodyStyle,
-  hideNavbar,
+  hideNavbar = false,
   children,
 }: PageLayoutProps) {
   const t = useTranslations('Nav');
@@ -59,7 +59,7 @@ export default function PageLayout({
         style={bodyStyle}
       >
         {children}
-        {hideNavbar !== true && <SubNavbar currentTab={currentPage} />}
+        {!hideNavbar && <SubNavbar currentTab={currentPage} />}
       </div>
     </div>
   );


### PR DESCRIPTION
- 공지/새소식/세미나 추가 및 편집 페이지에서 서브내비 숨김