### PR TITLE
✨ 소식 탭 목록 버튼을 누르면 원래 있던 목록으로 이동

### DIFF
--- a/app/[locale]/community/news/helper/NewsRow.tsx
+++ b/app/[locale]/community/news/helper/NewsRow.tsx
@@ -1,7 +1,6 @@
-import { Link } from '@/navigation';
-
 import ImageWithFallback from '@/components/common/ImageWithFallback';
 import Tags from '@/components/common/Tags';
+import PaginatedLink from '@/components/post/PaginatedLink';
 
 import { getPath } from '@/utils/page';
 import { news } from '@/utils/segmentNode';
@@ -52,11 +51,11 @@ export default function NewsRow({
         <time className="mb-2.5 mt-5 text-md text-neutral-800 sm:hidden">{dateStr}</time>
 
         <div className="flex flex-col items-start">
-          <Link href={href} className="hover:underline">
+          <PaginatedLink href={href} className="hover:underline">
             <h3 className="mb-2.5 text-base font-bold">{title}</h3>
-          </Link>
+          </PaginatedLink>
 
-          <Link
+          <PaginatedLink
             href={href}
             className="mb-3 line-clamp-3 break-all text-md font-normal leading-[1.6] text-neutral-500 hover:cursor-pointer sm:mb-8"
           >
@@ -71,7 +70,7 @@ export default function NewsRow({
             ) : (
               description
             )}
-          </Link>
+          </PaginatedLink>
         </div>
 
         <div className="flex items-center justify-between sm:gap-2.5">
@@ -82,7 +81,7 @@ export default function NewsRow({
         </div>
       </div>
 
-      <Link href={href} className="relative flex aspect-[4/3] sm:h-[9.375rem]">
+      <PaginatedLink href={href} className="relative flex aspect-[4/3] sm:h-[9.375rem]">
         <ImageWithFallback
           alt="포스트 대표 이미지"
           src={imageURL}
@@ -90,7 +89,7 @@ export default function NewsRow({
           className="object-cover"
           sizes="12.5rem"
         />
-      </Link>
+      </PaginatedLink>
     </article>
   );
 }

--- a/app/[locale]/community/notice/helper/NoticeListRow.tsx
+++ b/app/[locale]/community/notice/helper/NoticeListRow.tsx
@@ -1,8 +1,9 @@
-import { Link } from '@/navigation';
 import CheckboxOrange from '@/public/image/checkbox_orange.svg';
 import ClipIcon from '@/public/image/clip_icon.svg';
 import LockIcon from '@/public/image/lock_icon.svg';
 import PinIcon from '@/public/image/pin_icon.svg';
+
+import PaginatedLink from '@/components/post/PaginatedLink';
 
 import { NoticePreview } from '@/types/notice';
 
@@ -113,7 +114,7 @@ function TitleCell({ title, hasAttachment, id, isEditMode, isPinned }: TitleCell
   } else {
     return (
       <span className={`${NOTICE_ROW_CELL_WIDTH.title} min-w-0 grow sm:pl-3`}>
-        <Link
+        <PaginatedLink
           href={`${noticePath}/${id}`}
           className="flex items-center gap-1.5 font-semibold sm:font-normal"
         >
@@ -125,7 +126,7 @@ function TitleCell({ title, hasAttachment, id, isEditMode, isPinned }: TitleCell
             {title}
           </span>
           {hasAttachment && <ClipIcon className="shrink-0" />}
-        </Link>
+        </PaginatedLink>
       </span>
     );
   }

--- a/app/[locale]/community/seminar/helper/SeminarRow.tsx
+++ b/app/[locale]/community/seminar/helper/SeminarRow.tsx
@@ -1,11 +1,11 @@
 import { ElementType, PropsWithChildren } from 'react';
 
-import { Link } from '@/navigation';
 import Calendar from '@/public/image/calendar.svg';
 import Distance from '@/public/image/distance.svg';
 import Person from '@/public/image/person.svg';
 
 import ImageWithFallback from '@/components/common/ImageWithFallback';
+import PaginatedLink from '@/components/post/PaginatedLink';
 
 import { SeminarPreview } from '@/types/seminar';
 
@@ -25,7 +25,7 @@ export default function SeminarRow({
   const seminarPostPath = `${seminarPath}/${id}`;
 
   return (
-    <Link href={seminarPostPath}>
+    <PaginatedLink href={seminarPostPath}>
       <article className="group flex flex-col gap-4 sm:flex-row sm:gap-5">
         <ImageCell imageURL={imageURL} />
         <div className="flex flex-col items-start gap-1 break-all sm:gap-0">
@@ -36,7 +36,7 @@ export default function SeminarRow({
           </div>
         </div>
       </article>
-    </Link>
+    </PaginatedLink>
   );
 }
 

--- a/components/post/PaginatedLink.tsx
+++ b/components/post/PaginatedLink.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { ComponentProps } from 'react';
+
+import { Link } from '@/navigation';
+
+export default function PaginatedLink(
+  props: Omit<ComponentProps<typeof Link>, 'href'> & { href: string },
+) {
+  const pageNum = useSearchParams().get('pageNum');
+
+  const [pathStr, paramStr] = props.href.split('?');
+  const param = new URLSearchParams(paramStr);
+
+  if (pageNum) {
+    param.set('pageNum', pageNum);
+  }
+
+  const href = `${pathStr}?${param.toString()}`;
+
+  return <Link {...props} href={href} />;
+}

--- a/components/post/PostFooter.tsx
+++ b/components/post/PostFooter.tsx
@@ -4,6 +4,7 @@ import { News } from '@/types/news';
 import { Notice } from '@/types/notice';
 import { Seminar } from '@/types/seminar';
 
+import PaginatedLink from './PaginatedLink';
 import PostDeleteButton from './PostDeleteButton';
 import LoginVisible from '../common/LoginVisible';
 
@@ -89,12 +90,12 @@ function RowPostTitle({ title }: { title?: string }) {
 
 function PostListLink({ href }: { href: string }) {
   return (
-    <Link
+    <PaginatedLink
       href={href}
       className="flex h-[35px] items-center rounded-[0.0625rem] border border-neutral-700 bg-neutral-800 px-[15px] text-md font-semibold tracking-[0.1rem] text-white hover:border-neutral-500 hover:bg-neutral-500"
     >
       목록
-    </Link>
+    </PaginatedLink>
   );
 }
 


### PR DESCRIPTION
page.tsx에서 searchParams로 받아 아래로 넘겨주기에는 prop drilling이 심한 것 같아 Link쪽만 client component로 바꿔줬습니다.

`PaginatedLink`는 현재 페이지의 search param에 pageNum이 있다면 본인의 `href`의 뒤에 pageNum을 붙입니다. 

링크 컴포넌트 더 나은 이름 추천받음..