### PR TITLE
🔒️ 정수 오버플로우 수정

### DIFF
--- a/app/[locale]/community/news/page.tsx
+++ b/app/[locale]/community/news/page.tsx
@@ -25,10 +25,7 @@ interface NewsPageParams {
 }
 
 export default async function NewsPage({ searchParams }: NewsPageParams) {
-  if (
-    (searchParams.pageNum && !validatePageNum(searchParams.pageNum)) ||
-    (searchParams.tag !== undefined && !validateTag('news', searchParams.tag))
-  ) {
+  if (!validatePageNum(searchParams.pageNum) || !validateTag('news', searchParams.tag)) {
     notFound();
   }
 

--- a/app/[locale]/community/news/page.tsx
+++ b/app/[locale]/community/news/page.tsx
@@ -14,7 +14,7 @@ import { PostSearchQueryParams } from '@/types/post';
 
 import { getMetadata } from '@/utils/metadata';
 import { news } from '@/utils/segmentNode';
-import { validatePageNum } from '@/utils/validatePageNum';
+import { validatePageNum, validateTag } from '@/utils/validateSearchParams';
 
 export async function generateMetadata({ params: { locale } }: { params: { locale: string } }) {
   return await getMetadata({ locale, node: news });
@@ -25,7 +25,10 @@ interface NewsPageParams {
 }
 
 export default async function NewsPage({ searchParams }: NewsPageParams) {
-  if (searchParams.pageNum && !validatePageNum(searchParams.pageNum)) {
+  if (
+    (searchParams.pageNum && !validatePageNum(searchParams.pageNum)) ||
+    (searchParams.tag !== undefined && !validateTag('news', searchParams.tag))
+  ) {
     notFound();
   }
 

--- a/app/[locale]/community/notice/page.tsx
+++ b/app/[locale]/community/notice/page.tsx
@@ -25,10 +25,7 @@ interface NoticePageParams {
 }
 
 export default async function NoticePage({ searchParams }: NoticePageParams) {
-  if (
-    (searchParams.pageNum && !validatePageNum(searchParams.pageNum)) ||
-    (searchParams.tag !== undefined && !validateTag('notice', searchParams.tag))
-  ) {
+  if (validatePageNum(searchParams.pageNum) || !validateTag('notice', searchParams.tag)) {
     notFound();
   }
 

--- a/app/[locale]/community/notice/page.tsx
+++ b/app/[locale]/community/notice/page.tsx
@@ -14,17 +14,21 @@ import { PostSearchQueryParams } from '@/types/post';
 
 import { getMetadata } from '@/utils/metadata';
 import { notice } from '@/utils/segmentNode';
-import { validatePageNum } from '@/utils/validatePageNum';
+import { validatePageNum, validateTag } from '@/utils/validateSearchParams';
 
 export async function generateMetadata({ params: { locale } }: { params: { locale: string } }) {
   return await getMetadata({ locale, node: notice });
 }
+
 interface NoticePageParams {
   searchParams: PostSearchQueryParams;
 }
 
 export default async function NoticePage({ searchParams }: NoticePageParams) {
-  if (searchParams.pageNum && !validatePageNum(searchParams.pageNum)) {
+  if (
+    (searchParams.pageNum && !validatePageNum(searchParams.pageNum)) ||
+    (searchParams.tag !== undefined && !validateTag('notice', searchParams.tag))
+  ) {
     notFound();
   }
 

--- a/app/[locale]/community/seminar/SeminarContent.tsx
+++ b/app/[locale]/community/seminar/SeminarContent.tsx
@@ -12,7 +12,7 @@ import Pagination from '@/components/common/Pagination';
 
 import { PostSearchQueryParams } from '@/types/post';
 
-import { validatePageNum } from '@/utils/validatePageNum';
+import { validatePageNum } from '@/utils/validateSearchParams';
 
 const POSTS_COUNT_PER_PAGE = 10;
 

--- a/utils/validatePageNum.ts
+++ b/utils/validatePageNum.ts
@@ -1,5 +1,0 @@
-export const validatePageNum = (pageNumStr: string) => {
-  const pageNum = Number.parseInt(pageNumStr);
-  const isValid = Number.isNaN(pageNum) || pageNum < 1 ? false : true;
-  return isValid;
-};

--- a/utils/validateSearchParams.ts
+++ b/utils/validateSearchParams.ts
@@ -1,22 +1,20 @@
 import { NEWS_TAGS, NOTICE_TAGS } from '@/constants/tag';
 
-export const validatePageNum = (pageNumStr: string) => {
+export const validatePageNum = (pageNumStr?: string) => {
+  // pageNum 없을 경우는 validate 필요 X
+  if (!pageNumStr) return true;
+
   const pageNum = Number.parseInt(pageNumStr);
-  const isValid = Number.isNaN(pageNum) || pageNum < 1 ? false : true;
+  const isValid = !Number.isNaN(pageNum) && pageNum >= 1;
   return isValid;
 };
 
-export const validateTag = (category: 'notice' | 'news', tag: string | string[]) => {
+export const validateTag = (category: 'notice' | 'news', tag?: string | string[]) => {
+  // tag 없을 경우는 validate 필요 X
+  if (!tag) return true;
+
   const availableTags = category === 'notice' ? NOTICE_TAGS : NEWS_TAGS;
   const isTagValid = (singleTag: string) => availableTags.includes(singleTag);
 
-  let isValid = false;
-
-  if (Array.isArray(tag)) {
-    isValid = tag.every(isTagValid);
-  } else {
-    isValid = isTagValid(tag);
-  }
-
-  return isValid;
+  return Array.isArray(tag) ? tag.every(isTagValid) : isTagValid(tag);
 };

--- a/utils/validateSearchParams.ts
+++ b/utils/validateSearchParams.ts
@@ -1,0 +1,22 @@
+import { NEWS_TAGS, NOTICE_TAGS } from '@/constants/tag';
+
+export const validatePageNum = (pageNumStr: string) => {
+  const pageNum = Number.parseInt(pageNumStr);
+  const isValid = Number.isNaN(pageNum) || pageNum < 1 ? false : true;
+  return isValid;
+};
+
+export const validateTag = (category: 'notice' | 'news', tag: string | string[]) => {
+  const availableTags = category === 'notice' ? NOTICE_TAGS : NEWS_TAGS;
+  const isTagValid = (singleTag: string) => availableTags.includes(singleTag);
+
+  let isValid = false;
+
+  if (Array.isArray(tag)) {
+    isValid = tag.every(isTagValid);
+  } else {
+    isValid = isTagValid(tag);
+  }
+
+  return isValid;
+};


### PR DESCRIPTION
- 소식탭 공지와 새소식 태그에서 나오던 500 에러 태그 validation 추가해서 수정
- `validatePageNum` 파일명 `validateSearchParams`로 변경