### PR TITLE
✨ 행정직원 추가/수정/삭제 기능

### DIFF
--- a/actions/people.ts
+++ b/actions/people.ts
@@ -4,6 +4,8 @@ import { revalidateTag } from 'next/cache';
 
 import { redirect } from '@/navigation';
 
+import { postStaff } from '@/apis/people';
+
 import { FETCH_TAG_FACULTY, FETCH_TAG_STAFF } from '@/constants/network';
 
 import { getPath } from '@/utils/page';
@@ -31,9 +33,11 @@ export const deleteFacultyAction = withErrorHandler(async () => {
   redirect(facultyPath);
 });
 
-export const postStaffAction = withErrorHandler(async () => {
+export const postStaffAction = withErrorHandler(async (formData: FormData) => {
+  const res = await postStaff(formData);
+
   revalidateTag(FETCH_TAG_STAFF);
-  redirect(staffPath);
+  redirect(`${staffPath}/${res.ko.id}`);
 });
 
 export const putStaffAction = withErrorHandler(async (id: number) => {

--- a/actions/people.ts
+++ b/actions/people.ts
@@ -4,9 +4,11 @@ import { revalidateTag } from 'next/cache';
 
 import { redirect } from '@/navigation';
 
-import { postStaff } from '@/apis/people';
+import { deleteStaff, postStaff, putStaff } from '@/apis/people';
 
 import { FETCH_TAG_FACULTY, FETCH_TAG_STAFF } from '@/constants/network';
+
+import { WithLanguage } from '@/types/language';
 
 import { getPath } from '@/utils/page';
 import { emeritusFaculty, faculty, staff } from '@/utils/segmentNode';
@@ -40,12 +42,18 @@ export const postStaffAction = withErrorHandler(async (formData: FormData) => {
   redirect(`${staffPath}/${res.ko.id}`);
 });
 
-export const putStaffAction = withErrorHandler(async (id: number) => {
-  revalidateTag(FETCH_TAG_STAFF);
-  redirect(`${staffPath}/${id}`);
-});
+export const putStaffAction = withErrorHandler(
+  async (ids: WithLanguage<number>, formData: FormData) => {
+    await putStaff(ids, formData);
 
-export const deleteStaffAction = withErrorHandler(async () => {
+    revalidateTag(FETCH_TAG_STAFF);
+    redirect(`${staffPath}/${ids.ko}`);
+  },
+);
+
+export const deleteStaffAction = withErrorHandler(async (ids: WithLanguage<number>) => {
+  await deleteStaff(ids);
+
   revalidateTag(FETCH_TAG_STAFF);
   redirect(staffPath);
 });

--- a/actions/session.ts
+++ b/actions/session.ts
@@ -23,6 +23,7 @@ export const removeAuth = async () => {
   cookies().delete(COOKIE_SESSION_ID);
 };
 
+// TODO: getUserState로 이름 변경?
 export const getIsStaff = async (): Promise<UserState> => {
   const id = cookies().get(COOKIE_SESSION_ID);
   if (id === undefined) return 'logout';

--- a/apis/common.ts
+++ b/apis/common.ts
@@ -8,3 +8,8 @@ export const checkError = (response: Response) => {
   // server action 에러 처리를 위해 status code만 깔끔하게 담음
   throw new Error(response.status.toString());
 };
+
+export const BASE_URL2 =
+  process.env.NODE_ENV === 'development'
+    ? 'https://cse-dev-waffle.bacchus.io/api/v2'
+    : 'http://localhost:8080/api/v2';

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 
 import { objToQueryString } from '@/utils/convertParams';
 
-import { BASE_URL, checkError } from './common';
+import { BASE_URL, BASE_URL2, checkError } from './common';
 
 type CredentialRequestInit = RequestInit & { jsessionID?: boolean };
 
@@ -44,6 +44,39 @@ export const putRequest = async <T = unknown>(
 
 export const deleteRequest = async (url: string, init?: CredentialRequestInit) => {
   await fetchWithRetry(`${BASE_URL}${url}`, 'DELETE', init);
+};
+
+// BASE_URL v2 사용, 편집 기능 작업 끝나고 나면 어차피 사라질 부분이라 단순 복붙함
+// TODO: BASE_URL 통합
+
+export const getRequest2 = async <T = unknown>(
+  url: string,
+  params: object = {},
+  init?: CredentialRequestInit,
+): Promise<T> => {
+  const queryString = objToQueryString(params);
+  const resp = await fetchWithRetry(`${BASE_URL2}${url}${queryString}`, 'GET', init);
+  return await resp.json();
+};
+
+export const postRequest2 = async <T = unknown>(
+  url: string,
+  init?: CredentialRequestInit,
+): Promise<T> => {
+  const resp = await fetchWithRetry(`${BASE_URL2}${url}`, 'POST', init);
+  return await resp.json();
+};
+
+export const putRequest2 = async <T = unknown>(
+  url: string,
+  init?: CredentialRequestInit,
+): Promise<T | null> => {
+  const resp = await fetchWithRetry(`${BASE_URL2}${url}`, 'PUT', init);
+  return resp.headers.get('content-type') ? await resp.json() : null;
+};
+
+export const deleteRequest2 = async (url: string, init?: CredentialRequestInit) => {
+  await fetchWithRetry(`${BASE_URL2}${url}`, 'DELETE', init);
 };
 
 /**

--- a/apis/people.ts
+++ b/apis/people.ts
@@ -1,4 +1,4 @@
-import { Language } from '@/types/language';
+import { Language, WithLanguage } from '@/types/language';
 import {
   EmiritusFaculty,
   Faculty,
@@ -9,7 +9,16 @@ import {
   Staff,
 } from '@/types/people';
 
-import { deleteRequest, getRequest, postRequest, postRequest2, putRequest } from '.';
+import {
+  deleteRequest,
+  deleteRequest2,
+  getRequest,
+  getRequest2,
+  postRequest,
+  postRequest2,
+  putRequest,
+  putRequest2,
+} from '.';
 
 const facultyPath = '/professor';
 const staffPath = '/staff';
@@ -27,7 +36,7 @@ export const getEmeritusFaculty = (id: number) => getRequest<EmiritusFaculty>(`/
 export const getStaffList = (language: Language) =>
   getRequest<SimpleStaff[]>('/staff', { language });
 
-export const getStaff = (id: number) => getRequest<Staff>(`/staff/${id}`);
+export const getStaff = (id: number) => getRequest2<WithLanguage<Staff>>(`/staff/${id}`);
 
 export const postFaculty = async (formData: FormData) => {
   return postRequest(facultyPath, { body: formData, jsessionID: true }) as Promise<{
@@ -49,9 +58,9 @@ export const postStaff = async (formData: FormData) => {
   }>;
 };
 
-export const putStaff = async (id: number, formData: FormData) => {
-  await putRequest(`${staffPath}/${id}`, { body: formData, jsessionID: true });
+export const putStaff = async (ids: WithLanguage<number>, formData: FormData) => {
+  await putRequest2(`${staffPath}/${ids.ko}/${ids.en}`, { body: formData, jsessionID: true });
 };
 
-export const deleteStaff = async (id: number) =>
-  deleteRequest(`${staffPath}/${id}`, { jsessionID: true });
+export const deleteStaff = async (ids: WithLanguage<number>) =>
+  deleteRequest2(`${staffPath}/${ids.ko}/${ids.en}`, { jsessionID: true });

--- a/apis/people.ts
+++ b/apis/people.ts
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { FETCH_TAG_STAFF } from '@/constants/network';
 
 import { Language, WithLanguage } from '@/types/language';
 import {
@@ -25,6 +25,8 @@ import {
 const facultyPath = '/professor';
 const staffPath = '/staff';
 
+/* 교수진 */
+
 export const getActiveFacultyList = (language: Language) =>
   getRequest<FacultyList>('/professor/active', { language });
 
@@ -34,18 +36,6 @@ export const getEmeritusFacultyList = (language: Language) =>
   getRequest<SimpleEmiritusFaculty[]>('/professor/inactive', { language });
 
 export const getEmeritusFaculty = (id: number) => getRequest<EmiritusFaculty>(`/professor/${id}`);
-
-export const getStaffList = (language: Language) =>
-  getRequest<SimpleStaff[]>('/staff', { language });
-
-export const getStaff = (id: number) => {
-  try {
-    return getRequest2<WithLanguage<Staff>>(`/staff/${id}`);
-  } catch (e) {
-    console.log('eeee');
-    notFound();
-  }
-};
 
 export const postFaculty = async (formData: FormData) => {
   return postRequest(facultyPath, { body: formData, jsessionID: true }) as Promise<{
@@ -60,6 +50,17 @@ export const putFaculty = async (id: number, formData: FormData) => {
 
 export const deleteFaculty = async (id: number) =>
   deleteRequest(`${facultyPath}/${id}`, { jsessionID: true });
+
+/* 행정직원 */
+// TODO: /api/v1 v2 통합되면 request 메소드 원래대로 교체
+
+export const getStaffList = (language: Language) =>
+  getRequest2<SimpleStaff[]>('/staff', { language }, { next: { tags: [FETCH_TAG_STAFF] } });
+
+export const getStaff = (id: number) =>
+  getRequest2<WithLanguage<Staff>>(`/staff/${id}`, undefined, {
+    next: { tags: [FETCH_TAG_STAFF] },
+  });
 
 export const postStaff = async (formData: FormData) => {
   return postRequest2(staffPath, { body: formData, jsessionID: true }) as Promise<{

--- a/apis/people.ts
+++ b/apis/people.ts
@@ -9,7 +9,7 @@ import {
   Staff,
 } from '@/types/people';
 
-import { deleteRequest, getRequest, postRequest, putRequest } from '.';
+import { deleteRequest, getRequest, postRequest, postRequest2, putRequest } from '.';
 
 const facultyPath = '/professor';
 const staffPath = '/staff';
@@ -44,8 +44,8 @@ export const deleteFaculty = async (id: number) =>
   deleteRequest(`${facultyPath}/${id}`, { jsessionID: true });
 
 export const postStaff = async (formData: FormData) => {
-  return postRequest(staffPath, { body: formData, jsessionID: true }) as Promise<{
-    id: number;
+  return postRequest2(staffPath, { body: formData, jsessionID: true }) as Promise<{
+    ko: { id: number };
   }>;
 };
 

--- a/apis/people.ts
+++ b/apis/people.ts
@@ -1,3 +1,5 @@
+import { notFound } from 'next/navigation';
+
 import { Language, WithLanguage } from '@/types/language';
 import {
   EmiritusFaculty,
@@ -36,7 +38,14 @@ export const getEmeritusFaculty = (id: number) => getRequest<EmiritusFaculty>(`/
 export const getStaffList = (language: Language) =>
   getRequest<SimpleStaff[]>('/staff', { language });
 
-export const getStaff = (id: number) => getRequest2<WithLanguage<Staff>>(`/staff/${id}`);
+export const getStaff = (id: number) => {
+  try {
+    return getRequest2<WithLanguage<Staff>>(`/staff/${id}`);
+  } catch (e) {
+    console.log('eeee');
+    notFound();
+  }
+};
 
 export const postFaculty = async (formData: FormData) => {
   return postRequest(facultyPath, { body: formData, jsessionID: true }) as Promise<{

--- a/app/[locale]/people/staff/[id]/StaffMemberPageContent.tsx
+++ b/app/[locale]/people/staff/[id]/StaffMemberPageContent.tsx
@@ -34,8 +34,6 @@ export default function StaffMemberPageContent({
   const t = useTranslations('Content');
 
   // TODO: staff 수정 후 revalidate
-  // TODO: 한영 리다이렉트
-  // TODO: people 어드민 버튼 common과 통합
 
   const handleDelete = async () => {
     try {

--- a/app/[locale]/people/staff/[id]/StaffMemberPageContent.tsx
+++ b/app/[locale]/people/staff/[id]/StaffMemberPageContent.tsx
@@ -14,6 +14,8 @@ import { Staff } from '@/types/people';
 
 import { getPath } from '@/utils/page';
 import { staff } from '@/utils/segmentNode';
+import { handleServerAction } from '@/utils/serverActionError';
+import { errorToast } from '@/utils/toast';
 
 import BulletRow from '../../helper/BulletRow';
 import HeaderAndList from '../../helper/HeaderAndList';
@@ -31,8 +33,16 @@ export default function StaffMemberPageContent({
 }) {
   const t = useTranslations('Content');
 
+  // TODO: staff 수정 후 revalidate
+  // TODO: 한영 리다이렉트
+  // TODO: people 어드민 버튼 common과 통합
+
   const handleDelete = async () => {
-    await deleteStaffAction(ids);
+    try {
+      handleServerAction(await deleteStaffAction(ids));
+    } catch {
+      errorToast('오류가 발생했습니다');
+    }
   };
 
   return (

--- a/app/[locale]/people/staff/[id]/StaffMemberPageContent.tsx
+++ b/app/[locale]/people/staff/[id]/StaffMemberPageContent.tsx
@@ -33,8 +33,6 @@ export default function StaffMemberPageContent({
 }) {
   const t = useTranslations('Content');
 
-  // TODO: staff 수정 후 revalidate
-
   const handleDelete = async () => {
     try {
       handleServerAction(await deleteStaffAction(ids));

--- a/app/[locale]/people/staff/[id]/StaffMemberPageContent.tsx
+++ b/app/[locale]/people/staff/[id]/StaffMemberPageContent.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { deleteStaffAction } from '@/actions/people';
+import { Link } from '@/navigation';
+
+import { DeleteButton, EditButton } from '@/components/common/Buttons';
+import LoginVisible from '@/components/common/LoginVisible';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+
+import { WithLanguage } from '@/types/language';
+import { Staff } from '@/types/people';
+
+import { getPath } from '@/utils/page';
+import { staff } from '@/utils/segmentNode';
+
+import BulletRow from '../../helper/BulletRow';
+import HeaderAndList from '../../helper/HeaderAndList';
+import PageTitle from '../../helper/PageTitle';
+import ProfileImage from '../../helper/ProfileImage';
+
+const staffPath = getPath(staff);
+
+export default function StaffMemberPageContent({
+  staff,
+  ids,
+}: {
+  staff: Staff;
+  ids: WithLanguage<number>;
+}) {
+  const t = useTranslations('Content');
+
+  const handleDelete = async () => {
+    await deleteStaffAction(ids);
+  };
+
+  return (
+    <PageLayout
+      title={<PageTitle name={staff.name} academicRank={staff.role} />}
+      titleType="big"
+      titleMargin="mb-9"
+    >
+      <div className="relative mb-32 flex flex-col items-start sm:flex-row sm:gap-[3.75rem]">
+        <ProfileImage imageURL={staff.imageURL} />
+        <div className="mt-6 sm:mt-0">
+          <article className="mb-6 flex flex-col text-neutral-700">
+            <h3 className=" text-base font-bold leading-8">{t('연락처')}</h3>
+            <ul className="list-inside list-disc">
+              <BulletRow>
+                {t('위치')}: {staff.office}
+              </BulletRow>
+              <BulletRow>
+                {t('전화')}: {staff.phone}
+              </BulletRow>
+              <BulletRow>
+                {t('이메일')}:
+                <Link className="ml-1 text-link hover:underline" href={`mailto:${staff.email}`}>
+                  {staff.email}
+                </Link>
+              </BulletRow>
+            </ul>
+          </article>
+          <HeaderAndList header={t('주요 업무')} list={staff.tasks} />
+        </div>
+      </div>
+      <LoginVisible staff>
+        <div className="flex gap-3">
+          <DeleteButton onDelete={handleDelete} />
+          <EditButton href={`${staffPath}/${staff.id}/edit`} />
+        </div>
+      </LoginVisible>
+    </PageLayout>
+  );
+}

--- a/app/[locale]/people/staff/[id]/edit/page.tsx
+++ b/app/[locale]/people/staff/[id]/edit/page.tsx
@@ -1,0 +1,25 @@
+import { getStaff } from '@/apis/people';
+
+import InvalidIDFallback from '@/components/common/InvalidIDFallback';
+
+import { Language } from '@/types/language';
+
+import StaffEditPageContent from './StaffEditPageContent';
+
+interface FacultyEditPageProps {
+  params: { id: string; locale: Language };
+}
+
+export default async function StaffEditPage({
+  params: { id: rawId, locale },
+}: FacultyEditPageProps) {
+  try {
+    const id = +rawId;
+    if (Number.isNaN(id)) throw new Error('유효한 id가 아닙니다: ' + rawId);
+    const data = await getStaff(id);
+
+    return <StaffEditPageContent data={data} language={locale} />;
+  } catch {
+    return <InvalidIDFallback rawID={rawId} />;
+  }
+}

--- a/app/[locale]/people/staff/[id]/page.tsx
+++ b/app/[locale]/people/staff/[id]/page.tsx
@@ -2,6 +2,8 @@ import { getStaff } from '@/apis/people';
 
 import InvalidIDFallback from '@/components/common/InvalidIDFallback';
 
+import { Language } from '@/types/language';
+
 import { getMetadata } from '@/utils/metadata';
 
 import StaffMemberPageContent from './StaffMemberPageContent';
@@ -25,7 +27,7 @@ export async function generateMetadata({ params }: StaffMemberPageProps) {
 }
 
 interface StaffMemberPageProps {
-  params: { id: string; locale: string };
+  params: { id: string; locale: Language };
 }
 
 export default async function StaffMemberPage({ params }: StaffMemberPageProps) {
@@ -33,7 +35,12 @@ export default async function StaffMemberPage({ params }: StaffMemberPageProps) 
     const id = parseInt(params.id);
     const data = await getStaff(id);
 
-    return <StaffMemberPageContent staff={data.ko} ids={{ ko: data.ko.id, en: data.en.id }} />;
+    return (
+      <StaffMemberPageContent
+        staff={data[params.locale]}
+        ids={{ ko: data.ko.id, en: data.en.id }}
+      />
+    );
   } catch {
     return <InvalidIDFallback rawID={params.id} />;
   }

--- a/app/[locale]/people/staff/[id]/page.tsx
+++ b/app/[locale]/people/staff/[id]/page.tsx
@@ -1,24 +1,15 @@
-import { getTranslations } from 'next-intl/server';
-
-import { Link } from '@/navigation';
-
 import { getStaff } from '@/apis/people';
 
-import HeaderAndList from '@/app/[locale]/people/helper/HeaderAndList';
-
 import InvalidIDFallback from '@/components/common/InvalidIDFallback';
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
 
 import { getMetadata } from '@/utils/metadata';
 
-import BulletRow from '../../helper/BulletRow';
-import PageTitle from '../../helper/PageTitle';
-import ProfileImage from '../../helper/ProfileImage';
+import StaffMemberPageContent from './StaffMemberPageContent';
 
 export async function generateMetadata({ params }: StaffMemberPageProps) {
   try {
     const id = parseInt(params.id);
-    const staff = await getStaff(id);
+    const { ko: staff } = await getStaff(id);
 
     return await getMetadata({
       locale: params.locale,
@@ -40,40 +31,9 @@ interface StaffMemberPageProps {
 export default async function StaffMemberPage({ params }: StaffMemberPageProps) {
   try {
     const id = parseInt(params.id);
-    const staff = await getStaff(id);
-    const t = await getTranslations('Content');
+    const data = await getStaff(id);
 
-    return (
-      <PageLayout
-        title={<PageTitle name={staff.name} academicRank={staff.role} />}
-        titleType="big"
-        titleMargin="mb-9"
-      >
-        <div className="relative mb-32 flex flex-col items-start sm:flex-row sm:gap-[3.75rem]">
-          <ProfileImage imageURL={staff.imageURL} />
-          <div className="mt-6 sm:mt-0">
-            <article className="mb-6 flex flex-col text-neutral-700">
-              <h3 className=" text-base font-bold leading-8">{t('연락처')}</h3>
-              <ul className="list-inside list-disc">
-                <BulletRow>
-                  {t('위치')}: {staff.office}
-                </BulletRow>
-                <BulletRow>
-                  {t('전화')}: {staff.phone}
-                </BulletRow>
-                <BulletRow>
-                  {t('이메일')}:
-                  <Link className="ml-1 text-link hover:underline" href={`mailto:${staff.email}`}>
-                    {staff.email}
-                  </Link>
-                </BulletRow>
-              </ul>
-            </article>
-            <HeaderAndList header={t('주요 업무')} list={staff.tasks} />
-          </div>
-        </div>
-      </PageLayout>
-    );
+    return <StaffMemberPageContent staff={data.ko} ids={{ ko: data.ko.id, en: data.en.id }} />;
   } catch {
     return <InvalidIDFallback rawID={params.id} />;
   }

--- a/app/[locale]/people/staff/create/page.tsx
+++ b/app/[locale]/people/staff/create/page.tsx
@@ -3,14 +3,18 @@
 import { postStaffAction } from '@/actions/people';
 import { useRouter } from '@/navigation';
 
+import { isLocalImage } from '@/components/editor/PostEditorTypes';
 import StaffEditor, { StaffEditorContent } from '@/components/editor/StaffEditor';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 
-import { Language, WithLanguage } from '@/types/language';
+import { LANGUAGE, Language, WithLanguage } from '@/types/language';
+import { getKeys } from '@/types/object';
 
 import { validateStaffForm } from '@/utils/formValidation';
 import { getPath } from '@/utils/page';
 import { staff } from '@/utils/segmentNode';
+import { handleServerAction } from '@/utils/serverActionError';
+import { errorToast } from '@/utils/toast';
 
 const staffPath = getPath(staff);
 
@@ -21,7 +25,13 @@ export default function StaffCreatePage({ params: { locale } }: { params: { loca
 
   const handleComplete = async (content: WithLanguage<StaffEditorContent>) => {
     validateStaffForm(content);
-    postStaffAction();
+    const formData = contentToFormData(content);
+
+    try {
+      handleServerAction(await postStaffAction(formData));
+    } catch {
+      errorToast('오류가 발생했습니다');
+    }
   };
 
   return (
@@ -33,3 +43,34 @@ export default function StaffCreatePage({ params: { locale } }: { params: { loca
     </PageLayout>
   );
 }
+
+const contentToFormData = (content: WithLanguage<StaffEditorContent>) => {
+  const formData = new FormData();
+
+  formData.append(
+    'request',
+    new Blob([JSON.stringify(getRequestObject(content))], {
+      type: 'application/json',
+    }),
+  );
+
+  // 이미지는 한영 공통
+  if (content.ko.image && isLocalImage(content.ko.image)) {
+    formData.append('image', content.ko.image.file);
+  }
+
+  return formData;
+};
+
+const getRequestObject = (content: WithLanguage<StaffEditorContent>) =>
+  getKeys(LANGUAGE).reduce((acc, lang) => {
+    acc[lang] = {
+      name: content[lang].name,
+      role: content[lang].role,
+      office: content[lang].office,
+      phone: content[lang].phone,
+      email: content[lang].email,
+      tasks: content[lang].tasks,
+    };
+    return acc;
+  }, {} as WithLanguage);

--- a/app/[locale]/people/staff/page.tsx
+++ b/app/[locale]/people/staff/page.tsx
@@ -1,5 +1,6 @@
 import { getStaffList } from '@/apis/people';
 
+import { CreateButton } from '@/components/common/Buttons';
 import LoginVisible from '@/components/common/LoginVisible';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 
@@ -9,7 +10,6 @@ import { getMetadata } from '@/utils/metadata';
 import { getPath } from '@/utils/page';
 import { staff } from '@/utils/segmentNode';
 
-import { CreateButton } from '../helper/AdminButtons';
 import { PeopleCellProps } from '../helper/PeopleCell';
 import PeopleGrid from '../helper/PeopleGrid';
 
@@ -46,7 +46,7 @@ export default async function StaffPage({ params: { locale } }: StaffPageProps) 
   return (
     <PageLayout title="행정직원" titleType="big">
       <LoginVisible staff>
-        <CreateButton pathname={`${staffPath}/create`} />
+        <CreateButton href={`${staffPath}/create`} />
       </LoginVisible>
       <PeopleGrid contentList={contentList} />
     </PageLayout>

--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -1,5 +1,13 @@
 import { MouseEventHandler } from 'react';
 
+import { Link } from '@/navigation';
+
+import useModal from '@/utils/hooks/useModal';
+import { CustomError, handleServerAction } from '@/utils/serverActionError';
+import { errorToast, successToast } from '@/utils/toast';
+
+import AlertModal from '../modal/AlertModal';
+
 export function GrayButton({
   title,
   disabled,
@@ -41,5 +49,51 @@ export function BlackButton({
     >
       {title}
     </button>
+  );
+}
+
+export function CreateButton({ href }: { href: string }) {
+  return (
+    <div className="mb-9 max-w-[768px] text-right">
+      <Link href={href} className="inline-block">
+        <BlackButton title="추가하기" />
+      </Link>
+    </div>
+  );
+}
+
+export function DeleteButton({ onDelete }: { onDelete: () => Promise<CustomError | void> }) {
+  const { openModal } = useModal();
+
+  const handleDelete = async () => {
+    try {
+      handleServerAction(await onDelete());
+      successToast('구성원을 삭제했습니다.');
+    } catch (error) {
+      errorToast('구성원을 삭제하지 못했습니다.');
+    }
+  };
+
+  return (
+    <GrayButton
+      title="삭제"
+      onClick={() =>
+        openModal(
+          <AlertModal
+            message="구성원을 삭제하시겠습니까?"
+            confirmText="삭제"
+            onConfirm={handleDelete}
+          />,
+        )
+      }
+    />
+  );
+}
+
+export function EditButton({ href }: { href: string }) {
+  return (
+    <Link href={href} className="inline-block">
+      <GrayButton title="편집" />
+    </Link>
   );
 }

--- a/components/common/ImageWithFallback.tsx
+++ b/components/common/ImageWithFallback.tsx
@@ -12,7 +12,7 @@ export default function ImageWithFallback(props: ImageWithFallbackProps) {
   if (error || !props.src) {
     return (
       <div
-        className={`flex flex-1 items-center justify-center bg-neutral-100 ${
+        className={`flex items-center justify-center bg-neutral-100 ${
           props.fill && 'h-full w-full'
         }`}
         style={{ width: props.width, height: props.height }}

--- a/components/editor/FacultyEditor.tsx
+++ b/components/editor/FacultyEditor.tsx
@@ -69,6 +69,7 @@ export default function FacultyEditor({
   const currLangContent = content[language];
   const isInactiveFaculty = currLangContent.status === 'INACTIVE';
 
+  // status는 공통이므로 항상 동시에 처리
   const setFacultyStatus = (status: FacultyStatus) => {
     setContent((content) => ({
       ko: { ...content.ko, status },

--- a/components/editor/FacultyEditor.tsx
+++ b/components/editor/FacultyEditor.tsx
@@ -62,24 +62,19 @@ export default function FacultyEditor({
   labs,
 }: FacultyEditorProps) {
   const [language, setLanguage] = useState<Language>(initialLangauge);
-  const { content, setContent, setContentByKey } = useEditorContent(
+  const { content, setContentByKey } = useEditorContent(
     getFacultyEditorDefaultValue(initialFacultyStatus, initialContent),
     language,
   );
   const currLangContent = content[language];
   const isInactiveFaculty = currLangContent.status === 'INACTIVE';
 
-  // status는 공통이므로 항상 동시에 처리
-  const setFacultyStatus = (status: FacultyStatus) => {
-    setContent((content) => ({
-      ko: { ...content.ko, status },
-      en: { ...content.en, status },
-    }));
-  };
-
   return (
     <form className="flex flex-col">
-      <FacultyStatusFieldset selected={currLangContent.status} onChange={setFacultyStatus} />
+      <FacultyStatusFieldset
+        selected={currLangContent.status}
+        onChange={setContentByKey('status', true)}
+      />
 
       <LangauageFieldset selected={language} onChange={setLanguage} />
 

--- a/components/editor/StaffEditor.tsx
+++ b/components/editor/StaffEditor.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { Language, LANGUAGE, WithLanguage } from '@/types/language';
 import { getKeys } from '@/types/object';
+import { Staff } from '@/types/people';
 
 import useEditorContent from '@/utils/hooks/useEditorContent';
 
@@ -21,7 +22,6 @@ import Section from './common/Section';
 import { PostEditorImage } from './PostEditorTypes';
 
 export interface StaffEditorContent {
-  language: string;
   name: string;
   role: string;
   office: string;
@@ -35,7 +35,7 @@ interface StaffEditorProps {
   actions:
     | EditAction<WithLanguage<StaffEditorContent>>
     | CreateAction<WithLanguage<StaffEditorContent>>;
-  initialContent?: WithLanguage<StaffEditorContent>;
+  initialContent?: WithLanguage<Staff>;
   initialLangauge: Language;
 }
 
@@ -46,7 +46,7 @@ export default function StaffEditor({
 }: StaffEditorProps) {
   const [language, setLanguage] = useState<Language>(initialLangauge);
   const { content, setContentByKey } = useEditorContent(
-    initialContent || getStaffEditorDefaultValue(),
+    getInitialContent(initialContent),
     language,
   );
   const currLangContent = content[language];
@@ -197,20 +197,21 @@ function TasksFieldset({
   );
 }
 
-export const getStaffEditorDefaultValue = (): WithLanguage<StaffEditorContent> => {
-  const contentDetailDefaultValue: StaffEditorContent = {
-    language: 'ko',
-    name: '',
-    image: null,
-    phone: '',
-    email: '',
-    office: '',
-    tasks: [],
-    role: '',
-  };
-
+const getInitialContent = (initContent?: WithLanguage<Staff>): WithLanguage<StaffEditorContent> => {
   return {
-    ko: contentDetailDefaultValue,
-    en: { ...contentDetailDefaultValue, language: 'en' },
+    ko: getDefaultContentDetail(initContent?.ko),
+    en: getDefaultContentDetail(initContent?.en),
+  };
+};
+
+const getDefaultContentDetail = (content?: Staff): StaffEditorContent => {
+  return {
+    name: content?.name ?? '',
+    email: content?.email ?? '',
+    office: content?.office ?? '',
+    phone: content?.phone ?? '',
+    role: content?.role ?? '',
+    tasks: content?.tasks ?? [],
+    image: content?.imageURL ? { type: 'UPLOADED_IMAGE', url: content.imageURL } : null,
   };
 };

--- a/components/editor/StaffEditor.tsx
+++ b/components/editor/StaffEditor.tsx
@@ -136,7 +136,7 @@ function RoleFieldset({ value, onChange }: { value: string; onChange: (text: str
 
 function ImageFieldset({ file, setFile }: ImagePickerProps) {
   return (
-    <Fieldset title="사진" mb="mb-12" titleMb="mb-2" required>
+    <Fieldset title="사진" mb="mb-12" titleMb="mb-2">
       <label className="mb-3 whitespace-pre-wrap text-sm font-normal tracking-wide text-neutral-500">
         3:4 비율의 증명사진이 가장 적합합니다.
       </label>

--- a/components/editor/StaffEditor.tsx
+++ b/components/editor/StaffEditor.tsx
@@ -57,7 +57,7 @@ export default function StaffEditor({
 
       <NameFieldset value={currLangContent.name} onChange={setContentByKey('name')} />
       <RoleFieldset value={currLangContent.role} onChange={setContentByKey('role')} />
-      <ImageFieldset file={currLangContent.image} setFile={setContentByKey('image')} />
+      <ImageFieldset file={currLangContent.image} setFile={setContentByKey('image', true)} />
 
       <Section title="연락처 정보" titleMb="mb-3" mb="mb-12">
         <OfficeFieldset value={currLangContent.office} onChange={setContentByKey('office')} />
@@ -136,7 +136,7 @@ function RoleFieldset({ value, onChange }: { value: string; onChange: (text: str
 
 function ImageFieldset({ file, setFile }: ImagePickerProps) {
   return (
-    <Fieldset title="사진" mb="mb-12" titleMb="mb-2">
+    <Fieldset title="사진" mb="mb-12" titleMb="mb-2" required>
       <label className="mb-3 whitespace-pre-wrap text-sm font-normal tracking-wide text-neutral-500">
         3:4 비율의 증명사진이 가장 적합합니다.
       </label>

--- a/components/editor/common/ImagePicker.tsx
+++ b/components/editor/common/ImagePicker.tsx
@@ -48,7 +48,14 @@ const SelectedImageViewer = ({
 
   if (file.type !== 'LOCAL_IMAGE') {
     // TODO: 업로드된 이미지 예쁘게 보여주기
-    return <Image src={file.url} alt="선택된 이미지" width={100} height={100} />;
+    return (
+      <div className="flex w-fit items-end gap-2 border border-neutral-200 bg-neutral-50 p-2">
+        <Image src={file.url} alt="선택된 이미지" width={100} height={100} />
+        <button className="text-xs underline" onClick={removeFile}>
+          삭제
+        </button>
+      </div>
+    );
   }
 
   const imageURL = URL.createObjectURL(file.file);
@@ -62,7 +69,7 @@ const SelectedImageViewer = ({
     <div
       className={`
     relative flex gap-3 self-start
-    rounded-sm border-[1px] border-neutral-200 bg-neutral-50 
+    rounded-sm border border-neutral-200 bg-neutral-50 
     pb-2 pl-2 pr-4 pt-2`}
     >
       <Image

--- a/components/modal/AlertModal.tsx
+++ b/components/modal/AlertModal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useFormStatus } from 'react-dom';
 
 import useModal from '@/utils/hooks/useModal';

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,11 +22,7 @@ const isAuthRequired = (pathname: string) => {
 
   if (pathname.startsWith('/admin')) return true;
 
-  if (pathname.startsWith('/community')) {
-    return pathname.endsWith('create') || pathname.endsWith('edit');
-  } else {
-    return false;
-  }
+  return pathname.endsWith('create') || pathname.endsWith('edit');
 };
 
 export default async function middleware(request: NextRequest) {

--- a/types/language.ts
+++ b/types/language.ts
@@ -5,4 +5,4 @@ export const LANGUAGE = {
 
 export type Language = keyof typeof LANGUAGE;
 
-export type WithLanguage<T> = { [language in Language]: T };
+export type WithLanguage<T = object> = { [language in Language]: T };

--- a/types/people.ts
+++ b/types/people.ts
@@ -1,5 +1,3 @@
-import { Language } from './language';
-
 export const FACULTY_STATUS = {
   ACTIVE: '교수',
   INACTIVE: '역대 교수',
@@ -67,5 +65,4 @@ export interface SimpleStaff {
 
 export interface Staff extends SimpleStaff {
   tasks: string[];
-  language: Language;
 }

--- a/types/people.ts
+++ b/types/people.ts
@@ -1,3 +1,5 @@
+import { Language } from './language';
+
 export const FACULTY_STATUS = {
   ACTIVE: '교수',
   INACTIVE: '역대 교수',
@@ -65,4 +67,5 @@ export interface SimpleStaff {
 
 export interface Staff extends SimpleStaff {
   tasks: string[];
+  language: Language;
 }

--- a/utils/formValidation.ts
+++ b/utils/formValidation.ts
@@ -48,10 +48,13 @@ export const validateFacultyForm = (content: WithLanguage<FacultyEditorContent>)
 };
 
 export const validateStaffForm = (content: WithLanguage<StaffEditorContent>) => {
-  if (Object.entries(content.ko).some(([key, value]) => !value && key !== 'image')) {
-    throw new Error('필수 입력을 완료해주세요');
+  const isValueEmpty = (value: StaffEditorContent[keyof StaffEditorContent]) =>
+    !value || (Array.isArray(value) && value.length < 1);
+
+  if (Object.values(content.ko).some(isValueEmpty)) {
+    throw new Error('모든 정보를 입력해주세요');
   }
-  if (Object.entries(content.en).some(([key, value]) => !value && key !== 'image')) {
+  if (Object.values(content.en).some(isValueEmpty)) {
     throw new Error('영문 정보도 입력해주세요');
   }
 };

--- a/utils/formValidation.ts
+++ b/utils/formValidation.ts
@@ -51,10 +51,10 @@ export const validateStaffForm = (content: WithLanguage<StaffEditorContent>) => 
   const isValueEmpty = (value: StaffEditorContent[keyof StaffEditorContent]) =>
     !value || (Array.isArray(value) && value.length < 1);
 
-  if (Object.values(content.ko).some(isValueEmpty)) {
+  if (Object.entries(content.ko).some(([key, value]) => key !== 'image' && isValueEmpty(value))) {
     throw new Error('모든 정보를 입력해주세요');
   }
-  if (Object.values(content.en).some(isValueEmpty)) {
+  if (Object.entries(content.en).some(([key, value]) => key !== 'image' && isValueEmpty(value))) {
     throw new Error('영문 정보도 입력해주세요');
   }
 };

--- a/utils/hooks/useEditorContent.ts
+++ b/utils/hooks/useEditorContent.ts
@@ -4,24 +4,55 @@ import { useState } from 'react';
 
 import { Language, WithLanguage } from '@/types/language';
 
-export default function useEditorContent<T>(initialState: WithLanguage<T>, language: Language) {
-  const [content, setContent] = useState<WithLanguage<T>>(initialState);
+// 기본
+export default function useEditorContent<T>(initialState: T): {
+  content: T;
+  setContentByKey: <K extends keyof T>(key: K) => (value: T[K]) => void;
+  setContent: React.Dispatch<React.SetStateAction<T>>;
+};
+
+// content가 {ko: T, en: T} 구조일경우
+export default function useEditorContent<T>(
+  initialState: WithLanguage<T>,
+  language: Language,
+): {
+  content: WithLanguage<T>;
+  setContentByKey: <K extends keyof T>(key: K, commonAttribute?: boolean) => (value: T[K]) => void;
+  setContent: React.Dispatch<React.SetStateAction<WithLanguage<T>>>;
+};
+
+export default function useEditorContent<T>(
+  initialState: WithLanguage<T> | T,
+  language?: Language,
+) {
+  const [content, setContent] = useState<WithLanguage<T> | T>(initialState);
+
+  const isWithLanguage = (state: WithLanguage<T> | T): state is WithLanguage<T> => {
+    return state && typeof state === 'object' && 'ko' in state && 'en' in state;
+  };
 
   const setContentByKey =
     <K extends keyof T>(key: K, commonAttribute: boolean = false) =>
     (value: T[K]) => {
-      setContent((prev) =>
-        commonAttribute
-          ? // 한영 공통 속성
-            {
-              ko: { ...content.ko, [key]: value },
-              en: { ...content.en, [key]: value },
-            }
-          : {
-              ...prev,
-              [language]: { ...content[language], [key]: value },
-            },
-      );
+      setContent((prev) => {
+        if (language && isWithLanguage(prev)) {
+          return commonAttribute
+            ? // 한영 공통 속성인 경우
+              {
+                ko: { ...prev.ko, [key]: value },
+                en: { ...prev.en, [key]: value },
+              }
+            : {
+                ...prev,
+                [language]: { ...prev[language], [key]: value },
+              };
+        }
+
+        return {
+          ...prev,
+          [key]: value,
+        };
+      });
     };
 
   return { content, setContentByKey, setContent } as const;

--- a/utils/hooks/useEditorContent.ts
+++ b/utils/hooks/useEditorContent.ts
@@ -8,12 +8,20 @@ export default function useEditorContent<T>(initialState: WithLanguage<T>, langu
   const [content, setContent] = useState<WithLanguage<T>>(initialState);
 
   const setContentByKey =
-    <K extends keyof T>(key: K) =>
+    <K extends keyof T>(key: K, commonAttribute: boolean = false) =>
     (value: T[K]) => {
-      setContent((prev) => ({
-        ...prev,
-        [language]: { ...content[language], [key]: value },
-      }));
+      setContent((prev) =>
+        commonAttribute
+          ? // 한영 공통 속성
+            {
+              ko: { ...content.ko, [key]: value },
+              en: { ...content.en, [key]: value },
+            }
+          : {
+              ...prev,
+              [language]: { ...content[language], [key]: value },
+            },
+      );
     };
 
   return { content, setContentByKey, setContent } as const;


### PR DESCRIPTION
- 행정직원 편집 기능 구현
- `BASE_URL`을 `/api/v2`로 사용해야 해서 단순히 get, put, post, delete 메소드를 하나씩 더 만듦. 기존 함수에 파라미터 받아서 base url 구분할 수도 있지만 편집 기능 작업 끝내면 url은 다시 하나로 합쳐질 거라 기존 함수 수정하지 않고 새로 만듦.
- `ImagePicker`에 기존 사진 삭제 기능 추가
- 편집용 페이지 `/create`, `/edit`은 전부 auth 필요하도록 middleware 로직 수정
- 전에 `setContentByKey` 공통으로 빼려고 만들었던 `useEditorContent` 훅에서 한영 데이터와 한글만 있는 데이터 모두 사용 가능하도록 함수 오버로딩 사용하여 리팩토링