### PR TITLE
✨ 시설 안내, 찾아오는 길, 졸업생 진로 현황 편집 기능

### DIFF
--- a/actions/about.ts
+++ b/actions/about.ts
@@ -10,6 +10,7 @@ import {
   postFacility,
   putClub,
   putContact,
+  putDirections,
   putFacility,
   putGreetings,
   putHistory,
@@ -18,6 +19,7 @@ import {
 import {
   FETCH_TAG_CLUB,
   FETCH_TAG_CONTACT,
+  FETCH_TAG_DIRECTIONS,
   FETCH_TAG_FACILITIES,
   FETCH_TAG_GREETINGS,
   FETCH_TAG_HISTORY,
@@ -26,6 +28,7 @@ import {
 import { getPath } from '@/utils/page';
 import {
   contact,
+  directions,
   facilities,
   greetings,
   history,
@@ -118,3 +121,15 @@ export const putContactAction = withErrorHandler(async (formData: FormData) => {
   revalidateTag(FETCH_TAG_CONTACT);
   redirect(contactPath);
 });
+
+/** 찾아오는 길 */
+
+const directionsPath = getPath(directions);
+
+export const putDirectionsAction = withErrorHandler(
+  async (id: number, data: { koDescription: string; enDescription: string }) => {
+    await putDirections(id, data);
+    revalidateTag(FETCH_TAG_DIRECTIONS);
+    redirect(directionsPath);
+  },
+);

--- a/actions/about.ts
+++ b/actions/about.ts
@@ -6,9 +6,11 @@ import { redirect } from 'next/navigation';
 import {
   deleteClub,
   deleteFacility,
+  postCareerStat,
   postClub,
   postFacility,
   putCareerDescription,
+  putCareerStat,
   putClub,
   putContact,
   putDirections,
@@ -17,6 +19,7 @@ import {
   putHistory,
   putOverview,
 } from '@/apis/about';
+import { CareerStatEditorContent } from '@/components/editor/CareerStatEditor';
 import {
   FETCH_TAG_CAREER,
   FETCH_TAG_CLUB,
@@ -82,6 +85,18 @@ export const putCareerDescriptionAction = withErrorHandler(
     redirect(careerPath);
   },
 );
+
+export const postCareerStatAction = withErrorHandler(async (data: CareerStatEditorContent) => {
+  await postCareerStat(data);
+  revalidateTag(FETCH_TAG_CAREER);
+  redirect(careerPath);
+});
+
+export const putCareerStatAction = withErrorHandler(async (data: CareerStatEditorContent) => {
+  await putCareerStat(data);
+  revalidateTag(FETCH_TAG_CAREER);
+  redirect(careerPath);
+});
 
 /** 동아리 */
 

--- a/actions/about.ts
+++ b/actions/about.ts
@@ -4,11 +4,14 @@ import { revalidateTag } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import {
+  deleteCareerCompany,
   deleteClub,
   deleteFacility,
+  postCareerCompany,
   postCareerStat,
   postClub,
   postFacility,
+  putCareerCompany,
   putCareerDescription,
   putCareerStat,
   putClub,
@@ -94,6 +97,24 @@ export const postCareerStatAction = withErrorHandler(async (data: CareerStatEdit
 
 export const putCareerStatAction = withErrorHandler(async (data: CareerStatEditorContent) => {
   await putCareerStat(data);
+  revalidateTag(FETCH_TAG_CAREER);
+  redirect(careerPath);
+});
+
+export const postCareerCompanyAction = withErrorHandler(async (data: object) => {
+  await postCareerCompany(data);
+  revalidateTag(FETCH_TAG_CAREER);
+  redirect(careerPath);
+});
+
+export const putCareerCompanyAction = withErrorHandler(async (id: number, data: object) => {
+  await putCareerCompany(id, data);
+  revalidateTag(FETCH_TAG_CAREER);
+  redirect(careerPath);
+});
+
+export const deleteCareerCompanyAction = withErrorHandler(async (id: number) => {
+  await deleteCareerCompany(id);
   revalidateTag(FETCH_TAG_CAREER);
   redirect(careerPath);
 });

--- a/actions/about.ts
+++ b/actions/about.ts
@@ -33,6 +33,7 @@ import {
   FETCH_TAG_HISTORY,
   FETCH_TAG_OVERVIEW,
 } from '@/constants/network';
+import { FutureCareers } from '@/types/about';
 import { getPath } from '@/utils/page';
 import {
   contact,
@@ -101,17 +102,21 @@ export const putCareerStatAction = withErrorHandler(async (data: CareerStatEdito
   redirect(careerPath);
 });
 
-export const postCareerCompanyAction = withErrorHandler(async (data: object) => {
-  await postCareerCompany(data);
-  revalidateTag(FETCH_TAG_CAREER);
-  redirect(careerPath);
-});
+export const postCareerCompanyAction = withErrorHandler(
+  async (data: { name: string; url?: string; year: number }) => {
+    await postCareerCompany(data);
+    revalidateTag(FETCH_TAG_CAREER);
+    redirect(careerPath);
+  },
+);
 
-export const putCareerCompanyAction = withErrorHandler(async (id: number, data: object) => {
-  await putCareerCompany(id, data);
-  revalidateTag(FETCH_TAG_CAREER);
-  redirect(careerPath);
-});
+export const putCareerCompanyAction = withErrorHandler(
+  async (id: number, data: FutureCareers['companies'][number]) => {
+    await putCareerCompany(id, data);
+    revalidateTag(FETCH_TAG_CAREER);
+    redirect(careerPath);
+  },
+);
 
 export const deleteCareerCompanyAction = withErrorHandler(async (id: number) => {
   await deleteCareerCompany(id);

--- a/actions/about.ts
+++ b/actions/about.ts
@@ -8,6 +8,7 @@ import {
   deleteFacility,
   postClub,
   postFacility,
+  putCareerDescription,
   putClub,
   putContact,
   putDirections,
@@ -17,6 +18,7 @@ import {
   putOverview,
 } from '@/apis/about';
 import {
+  FETCH_TAG_CAREER,
   FETCH_TAG_CLUB,
   FETCH_TAG_CONTACT,
   FETCH_TAG_DIRECTIONS,
@@ -30,6 +32,7 @@ import {
   contact,
   directions,
   facilities,
+  futureCareers,
   greetings,
   history,
   overview,
@@ -67,6 +70,18 @@ export const putHistoryAction = withErrorHandler(async (formData: FormData) => {
   revalidateTag(FETCH_TAG_HISTORY);
   redirect(historyPath);
 });
+
+/** 졸업생 진로 */
+
+const careerPath = getPath(futureCareers);
+
+export const putCareerDescriptionAction = withErrorHandler(
+  async (data: { koDescription: string; enDescription: string }) => {
+    await putCareerDescription(data);
+    revalidateTag(FETCH_TAG_CAREER);
+    redirect(careerPath);
+  },
+);
 
 /** 동아리 */
 

--- a/apis/about.ts
+++ b/apis/about.ts
@@ -72,14 +72,14 @@ export const putCareerStat = (data: CareerStatEditorContent) =>
     jsessionID: true,
   });
 
-export const postCareerCompany = (data: object) =>
+export const postCareerCompany = (data: { name: string; url?: string; year: number }) =>
   postRequestV2('/about/future-careers/company', {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
     jsessionID: true,
   });
 
-export const putCareerCompany = (id: number, data: object) =>
+export const putCareerCompany = (id: number, data: FutureCareers['companies'][number]) =>
   putRequestV2(`/about/future-careers/company/${id}`, {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),

--- a/apis/about.ts
+++ b/apis/about.ts
@@ -64,7 +64,7 @@ export const deleteClub = (id: number) =>
 /** 시설 안내 */
 
 export const getFacilities = () =>
-  getRequest<Facility[]>('/about/facilities', undefined, {
+  getRequestV2<WithLanguage<Facility>[]>('/about/facilities', undefined, {
     next: { tags: [FETCH_TAG_FACILITIES] },
   });
 

--- a/apis/about.ts
+++ b/apis/about.ts
@@ -1,4 +1,5 @@
 import {
+  FETCH_TAG_CAREER,
   FETCH_TAG_CLUB,
   FETCH_TAG_CONTACT,
   FETCH_TAG_DIRECTIONS,
@@ -32,7 +33,10 @@ export const getGreetings = (language: Language) =>
 export const putGreetings = (formData: FormData) =>
   putRequestV2('/about/greetings', { body: formData, jsessionID: true });
 
-export const getFutureCareeres = () => getRequest<FutureCareers>('/about/future-careers');
+export const getFutureCareeres = (language: Language) =>
+  getRequest<FutureCareers>(`/about/future-careers?language=${language}`, undefined, {
+    next: { tags: [FETCH_TAG_CAREER] },
+  });
 
 /** 연혁 */
 
@@ -43,6 +47,15 @@ export const getHistory = (language: Language) =>
 
 export const putHistory = (formData: FormData) =>
   putRequestV2('/about/history', { body: formData, jsessionID: true });
+
+/** 졸업생 진로  */
+
+export const putCareerDescription = (data: { koDescription: string; enDescription: string }) =>
+  putRequestV2('/about/future-careers', {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+    jsessionID: true,
+  });
 
 /** 동아리 */
 

--- a/apis/about.ts
+++ b/apis/about.ts
@@ -72,6 +72,23 @@ export const putCareerStat = (data: CareerStatEditorContent) =>
     jsessionID: true,
   });
 
+export const postCareerCompany = (data: object) =>
+  postRequestV2('/about/future-careers/company', {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+    jsessionID: true,
+  });
+
+export const putCareerCompany = (id: number, data: object) =>
+  putRequestV2(`/about/future-careers/company/${id}`, {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+    jsessionID: true,
+  });
+
+export const deleteCareerCompany = (id: number) =>
+  deleteRequestV2(`/about/future-careers/company/${id}`, { jsessionID: true });
+
 /** 동아리 */
 
 export const getClubs = () =>

--- a/apis/about.ts
+++ b/apis/about.ts
@@ -1,6 +1,7 @@
 import {
   FETCH_TAG_CLUB,
   FETCH_TAG_CONTACT,
+  FETCH_TAG_DIRECTIONS,
   FETCH_TAG_FACILITIES,
   FETCH_TAG_GREETINGS,
   FETCH_TAG_HISTORY,
@@ -32,8 +33,6 @@ export const putGreetings = (formData: FormData) =>
   putRequestV2('/about/greetings', { body: formData, jsessionID: true });
 
 export const getFutureCareeres = () => getRequest<FutureCareers>('/about/future-careers');
-
-export const getDirections = () => getRequest<Direction[]>('/about/directions');
 
 /** 연혁 */
 
@@ -86,3 +85,17 @@ export const getContact = (language: Language) =>
 
 export const putContact = (formData: FormData) =>
   putRequestV2('/about/contact', { body: formData, jsessionID: true });
+
+/** 찾아오는 길 */
+
+export const getDirections = () =>
+  getRequestV2<WithLanguage<Direction>[]>('/about/directions', undefined, {
+    next: { tags: [FETCH_TAG_DIRECTIONS] },
+  });
+
+export const putDirections = (id: number, data: { koDescription: string; enDescription: string }) =>
+  putRequestV2(`/about/directions/${id}`, {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+    jsessionID: true,
+  });

--- a/apis/about.ts
+++ b/apis/about.ts
@@ -1,3 +1,4 @@
+import { CareerStatEditorContent } from '@/components/editor/CareerStatEditor';
 import {
   FETCH_TAG_CAREER,
   FETCH_TAG_CLUB,
@@ -33,11 +34,6 @@ export const getGreetings = (language: Language) =>
 export const putGreetings = (formData: FormData) =>
   putRequestV2('/about/greetings', { body: formData, jsessionID: true });
 
-export const getFutureCareeres = (language: Language) =>
-  getRequest<FutureCareers>(`/about/future-careers?language=${language}`, undefined, {
-    next: { tags: [FETCH_TAG_CAREER] },
-  });
-
 /** 연혁 */
 
 export const getHistory = (language: Language) =>
@@ -50,8 +46,27 @@ export const putHistory = (formData: FormData) =>
 
 /** 졸업생 진로  */
 
+export const getFutureCareeres = (language: Language) =>
+  getRequest<FutureCareers>(`/about/future-careers?language=${language}`, undefined, {
+    next: { tags: [FETCH_TAG_CAREER] },
+  });
+
 export const putCareerDescription = (data: { koDescription: string; enDescription: string }) =>
   putRequestV2('/about/future-careers', {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+    jsessionID: true,
+  });
+
+export const postCareerStat = (data: CareerStatEditorContent) =>
+  postRequestV2('/about/future-careers/stats', {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+    jsessionID: true,
+  });
+
+export const putCareerStat = (data: CareerStatEditorContent) =>
+  putRequestV2('/about/future-careers/stats', {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
     jsessionID: true,

--- a/app/[locale]/about/directions/DirectionsDetails.tsx
+++ b/app/[locale]/about/directions/DirectionsDetails.tsx
@@ -14,11 +14,9 @@ export default function DirectionsDetails({ direction }: { direction: Direction 
       <div className="justify-between sm:flex">
         <DirectionsTitle name={direction.name} />
         <LoginVisible staff>
-          <div className="flex h-fit justify-end gap-3">
-            <EditButton
-              href={`${directionsPath}/edit?selected=${replaceSpaceWithDash(direction.name)}`}
-            />
-          </div>
+          <EditButton
+            href={`${directionsPath}/edit?selected=${replaceSpaceWithDash(direction.name)}`}
+          />
         </LoginVisible>
       </div>
       <HTMLViewer htmlContent={direction.description} className="ml-2.5" />

--- a/app/[locale]/about/directions/DirectionsDetails.tsx
+++ b/app/[locale]/about/directions/DirectionsDetails.tsx
@@ -1,32 +1,31 @@
+import { EditButton } from '@/components/common/Buttons';
+import LoginVisible from '@/components/common/LoginVisible';
 import HTMLViewer from '@/components/editor/HTMLViewer';
 import { Direction } from '@/types/about';
+import { getPath } from '@/utils/page';
+import { directions } from '@/utils/segmentNode';
+import { replaceSpaceWithDash } from '@/utils/string';
+
+const directionsPath = getPath(directions);
 
 export default function DirectionsDetails({ direction }: { direction: Direction }) {
   return (
     <div>
-      <DirectionsTitle name={direction.name} />
+      <div className="justify-between sm:flex">
+        <DirectionsTitle name={direction.name} />
+        <LoginVisible staff>
+          <div className="flex h-fit justify-end gap-3">
+            <EditButton
+              href={`${directionsPath}/edit?selected=${replaceSpaceWithDash(direction.name)}`}
+            />
+          </div>
+        </LoginVisible>
+      </div>
       <HTMLViewer htmlContent={direction.description} className="ml-2.5" />
     </div>
   );
 }
 
-const getDirectionsPostposition = (directionName: string) => {
-  if (directionName === '대중교통') {
-    return '으로';
-  } else if (directionName === '승용차') {
-    return '로';
-  } else if (directionName === '지방 및 해외') {
-    return '에서';
-  } else {
-    console.error('값이 올바르지 않습니다.');
-    return '';
-  }
-};
-
 function DirectionsTitle({ name }: { name: string }) {
-  return (
-    <h4 className="mb-4 h-10 text-base font-bold sm:text-[24px]">{`${name}${getDirectionsPostposition(
-      name,
-    )} 오는 방법`}</h4>
-  );
+  return <h4 className="mb-4 h-10 text-base font-bold sm:text-[24px]">{name}</h4>;
 }

--- a/app/[locale]/about/directions/edit/DirectionsEditPageContent.tsx
+++ b/app/[locale]/about/directions/edit/DirectionsEditPageContent.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { putDirectionsAction } from '@/actions/about';
+import BasicEditor, { BasicEditorContent } from '@/components/editor/BasicEditor';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { useRouter } from '@/navigation';
+import { Direction } from '@/types/about';
+import { WithLanguage } from '@/types/language';
+import { errorToStr } from '@/utils/error';
+import { validateBasicForm } from '@/utils/formValidation';
+import { getPath } from '@/utils/page';
+import { directions } from '@/utils/segmentNode';
+import { handleServerAction } from '@/utils/serverActionError';
+import { errorToast, successToast } from '@/utils/toast';
+
+const directionsPath = getPath(directions);
+
+export default function DirectionsEditPageContent({ data }: { data: WithLanguage<Direction> }) {
+  const router = useRouter();
+
+  const handleCancel = () => router.push(directionsPath);
+
+  const handleSubmit = async (content: BasicEditorContent) => {
+    validateBasicForm(content);
+
+    const newData = {
+      koDescription: content.description.ko,
+      enDescription: content.description.en,
+    };
+
+    try {
+      handleServerAction(await putDirectionsAction(data.ko.id, newData));
+      successToast('찾아오는 길을 수정했습니다.');
+    } catch (e) {
+      errorToast(errorToStr(e));
+    }
+  };
+
+  return (
+    <PageLayout title={`찾아오는 길(${data.ko.name}) 편집`} titleType="big" hideNavbar>
+      <BasicEditor
+        initialContent={{
+          name: { ko: data.ko.name, en: data.en.name },
+          description: { ko: data.ko.description, en: data.en.description },
+        }}
+        actions={{ type: 'EDIT', onCancel: handleCancel, onSubmit: handleSubmit }}
+        showLanguage
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/about/directions/edit/page.tsx
+++ b/app/[locale]/about/directions/edit/page.tsx
@@ -1,0 +1,20 @@
+import { getDirections } from '@/apis/about';
+import { findItemBySearchParam } from '@/utils/findSelectedItem';
+
+import DirectionsEditPageContent from './DirectionsEditPageContent';
+
+interface DirectionsEditPageProps {
+  searchParams: { selected?: string };
+}
+
+export default async function DirectionsEditPage({ searchParams }: DirectionsEditPageProps) {
+  const directionList = await getDirections();
+  const selectedDirection =
+    findItemBySearchParam(
+      directionList,
+      (item) => [item.en.name, item.ko.name],
+      searchParams.selected,
+    ) || directionList[0];
+
+  return <DirectionsEditPageContent data={selectedDirection} />;
+}

--- a/app/[locale]/about/directions/page.tsx
+++ b/app/[locale]/about/directions/page.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 import { getDirections } from '@/apis/about';
 import SelectionList from '@/components/common/selection/SelectionList';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { Language } from '@/types/language';
 import { findItemBySearchParam } from '@/utils/findSelectedItem';
 import { getMetadata } from '@/utils/metadata';
 import { getPath } from '@/utils/page';
@@ -19,6 +20,7 @@ export async function generateMetadata({ params: { locale } }: { params: { local
 }
 
 interface DirectionsPageProps {
+  params: { locale: Language };
   searchParams: { selected?: string };
 }
 
@@ -26,11 +28,11 @@ const directionsPath = getPath(directions);
 const FIND_PATH_URL =
   'https://map.naver.com/v5/directions/-/14132304.586627584,4502018.066849938,%EC%84%9C%EC%9A%B8%EB%8C%80%ED%95%99%EA%B5%90%EA%B4%80%EC%95%85%EC%BA%A0%ED%8D%BC%EC%8A%A4%EC%A0%9C1%EA%B3%B5%ED%95%99%EA%B4%80,18721800,PLACE_POI/-/transit?c=15,0,0,0,dh';
 
-export default async function DirectionsPage({ searchParams }: DirectionsPageProps) {
+export default async function DirectionsPage({ searchParams, params }: DirectionsPageProps) {
   const directionList = await getDirections();
   const selectedDirection = findItemBySearchParam(
     directionList,
-    (item) => [item.name],
+    (item) => [item.ko.name, item.en.name],
     searchParams.selected,
   );
 
@@ -41,12 +43,12 @@ export default async function DirectionsPage({ searchParams }: DirectionsPagePro
         <LocationMap />
       </div>
       <SelectionList
-        names={directionList.map((d) => ({ ko: d.name }))}
-        selectedItemNameKo={selectedDirection?.name ?? ''}
+        names={directionList.map((d) => ({ ko: d.ko.name, en: d.en.name }))}
+        selectedItemNameKo={selectedDirection?.ko.name ?? ''}
         rootPath={directionsPath}
       />
       {selectedDirection ? (
-        <DirectionsDetails direction={selectedDirection} />
+        <DirectionsDetails direction={selectedDirection[params.locale]} />
       ) : (
         <NotFoundLabel>{searchParams.selected}</NotFoundLabel>
       )}

--- a/app/[locale]/about/facilities/edit/FacilitiesEditPageContent.tsx
+++ b/app/[locale]/about/facilities/edit/FacilitiesEditPageContent.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { putFacilityAction } from '@/actions/about';
+import FacilityEditor, { FacilityEditorContent } from '@/components/editor/FacilityEditor';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { useRouter } from '@/navigation';
+import { Facility } from '@/types/about';
+import { WithLanguage } from '@/types/language';
+import { errorToStr } from '@/utils/error';
+import { contentToFormData } from '@/utils/formData';
+import { validateFacilityForm } from '@/utils/formValidation';
+import { getPath } from '@/utils/page';
+import { facilities } from '@/utils/segmentNode';
+import { handleServerAction } from '@/utils/serverActionError';
+import { errorToast, successToast } from '@/utils/toast';
+
+const facilitiesPath = getPath(facilities);
+
+export default function FacilitiesEditPageContent({ data }: { data: WithLanguage<Facility> }) {
+  const router = useRouter();
+
+  const handleCancel = () => router.push(facilitiesPath);
+
+  const handleSubmit = async (content: WithLanguage<FacilityEditorContent>) => {
+    validateFacilityForm(content);
+    const formData = contentToFormData('EDIT', {
+      requestObject: getRequestObject(
+        content,
+        data.ko.imageURL !== null && content.ko.mainImage === null,
+      ),
+      image: content.ko.mainImage,
+    });
+
+    try {
+      handleServerAction(await putFacilityAction(data.ko.id, formData));
+      successToast('시설 안내를 수정했습니다.');
+    } catch (e) {
+      errorToast(errorToStr(e));
+    }
+  };
+
+  return (
+    <PageLayout title="시설 안내 편집" titleType="big" hideNavbar>
+      <FacilityEditor
+        initialContent={data}
+        actions={{ type: 'EDIT', onCancel: handleCancel, onSubmit: handleSubmit }}
+      />
+    </PageLayout>
+  );
+}
+
+const getRequestObject = (content: WithLanguage<FacilityEditorContent>, removeImage: boolean) => {
+  const mainImage = undefined; // 이미지는 따로 보내야 하므로 requestObj에서 제외
+
+  return {
+    ko: { ...content.ko, mainImage },
+    en: { ...content.en, mainImage },
+    removeImage,
+  };
+};

--- a/app/[locale]/about/facilities/edit/page.tsx
+++ b/app/[locale]/about/facilities/edit/page.tsx
@@ -1,9 +1,20 @@
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { getFacilities } from '@/apis/about';
+import { findItemBySearchParam } from '@/utils/findSelectedItem';
 
-export default function FacilitiesEditPage() {
-  return (
-    <PageLayout title="시설 안내 편집" titleType="big" hideNavbar>
-      <div>개발중입니다. 조금만 기다려주세요...</div>
-    </PageLayout>
-  );
+import FacilitiesEditPageContent from './FacilitiesEditPageContent';
+
+interface FacilitiesEditPageProps {
+  searchParams: { id: string };
+}
+
+export default async function FacilitiesEditPage({ searchParams }: FacilitiesEditPageProps) {
+  const facilities = await getFacilities();
+  const selectedFacility =
+    findItemBySearchParam(
+      facilities,
+      (item) => [item.en.id.toString(), item.ko.id.toString()],
+      searchParams.id,
+    ) || facilities[0];
+
+  return <FacilitiesEditPageContent data={selectedFacility} />;
 }

--- a/app/[locale]/about/facilities/page.tsx
+++ b/app/[locale]/about/facilities/page.tsx
@@ -6,17 +6,22 @@ import { OrangeButton } from '@/components/common/Buttons';
 import LoginVisible from '@/components/common/LoginVisible';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { Link } from '@/navigation';
+import { Language } from '@/types/language';
 import { getMetadata } from '@/utils/metadata';
 import { getPath } from '@/utils/page';
 import { facilities } from '@/utils/segmentNode';
 
-export async function generateMetadata({ params: { locale } }: { params: { locale: string } }) {
+export async function generateMetadata({ params: { locale } }: { params: { locale: Language } }) {
   return await getMetadata({ locale, node: facilities });
+}
+
+interface FacilitiesPageProps {
+  params: { locale: Language };
 }
 
 const facilitiesPath = getPath(facilities);
 
-export default async function FacilitiesPage() {
+export default async function FacilitiesPage({ params }: FacilitiesPageProps) {
   const facilities = await getFacilities();
 
   return (
@@ -28,7 +33,7 @@ export default async function FacilitiesPage() {
           </Link>
         </div>
       </LoginVisible>
-      <FacilitesList facilities={facilities} />
+      <FacilitesList facilities={facilities.map((facility) => facility[params.locale])} />
     </PageLayout>
   );
 }

--- a/app/[locale]/about/future-careers/CareerCompanies.tsx
+++ b/app/[locale]/about/future-careers/CareerCompanies.tsx
@@ -6,7 +6,7 @@ export default function CareerCompanies({ companies }: { companies: FutureCareer
   const t = useTranslations('Content');
 
   return (
-    <div className="sm:max-w-[780px]">
+    <div className="mt-11 sm:max-w-[780px]">
       <h3 className="mb-3 text-base font-bold">{t('졸업생 창업 기업')}</h3>
       <div className="border-y border-neutral-200 text-sm font-normal">
         <CompanyTableHeader />

--- a/app/[locale]/about/future-careers/CareerCompanies.tsx
+++ b/app/[locale]/about/future-careers/CareerCompanies.tsx
@@ -1,18 +1,35 @@
-import { useTranslations } from 'next-intl';
+'use client';
 
+import { useTranslations } from 'next-intl';
+import { useReducer } from 'react';
+
+import { deleteCareerCompanyAction, putCareerCompanyAction } from '@/actions/about';
+import { BlackButton, GrayButton, OrangeButton } from '@/components/common/Buttons';
+import LoginVisible from '@/components/common/LoginVisible';
+import BasicTextInput from '@/components/editor/common/BasicTextInput';
 import { FutureCareers } from '@/types/about';
+import { errorToStr } from '@/utils/error';
+import useEditorContent from '@/utils/hooks/useEditorContent';
+import { isNumber } from '@/utils/number';
+import { handleServerAction } from '@/utils/serverActionError';
+import { errorToast, successToast } from '@/utils/toast';
 
 export default function CareerCompanies({ companies }: { companies: FutureCareers['companies'] }) {
   const t = useTranslations('Content');
 
   return (
-    <div className="mt-11 sm:max-w-[780px]">
-      <h3 className="mb-3 text-base font-bold">{t('졸업생 창업 기업')}</h3>
+    <div className="mt-11 sm:max-w-fit">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-base font-bold">{t('졸업생 창업 기업')}</h3>
+        <LoginVisible staff>
+          <OrangeButton title="기업 추가" />
+        </LoginVisible>
+      </div>
       <div className="border-y border-neutral-200 text-sm font-normal">
         <CompanyTableHeader />
         <ol>
           {companies.map((company, index) => (
-            <CompanyTableRow key={index} index={index + 1} {...company} />
+            <CompanyTableRow key={index} index={index + 1} company={company} />
           ))}
         </ol>
       </div>
@@ -20,7 +37,7 @@ export default function CareerCompanies({ companies }: { companies: FutureCareer
   );
 }
 
-const TABLE_COLUMN_SIZE = ['sm:w-[3.5rem]', 'sm:w-[12.5rem]', 'sm:w-80', 'sm:w-20'];
+const TABLE_COLUMN_SIZE = ['sm:w-[3rem]', 'sm:w-[12.5rem]', 'sm:w-80', 'sm:w-20'];
 
 function CompanyTableHeader() {
   const t = useTranslations('Content');
@@ -28,29 +45,57 @@ function CompanyTableHeader() {
   return (
     <div className="hidden h-10 items-center gap-3 whitespace-nowrap border-b border-neutral-200 sm:flex sm:px-3">
       <p className={TABLE_COLUMN_SIZE[0]}>{t('연번')}</p>
-      <p className={TABLE_COLUMN_SIZE[1]}>{t('창업 기업명')}</p>
-      <p className={TABLE_COLUMN_SIZE[2]}>{t('홈페이지')}</p>
-      <p className={TABLE_COLUMN_SIZE[3] + ''}>{t('창업연도')}</p>
+      <p className={`${TABLE_COLUMN_SIZE[1]} pl-2`}>{t('창업 기업명')}</p>
+      <p className={`${TABLE_COLUMN_SIZE[2]} pl-2`}>{t('홈페이지')}</p>
+      <p className={`${TABLE_COLUMN_SIZE[3]} pl-2`}>{t('창업연도')}</p>
+      <p className="w-32" />
     </div>
   );
 }
 
 interface CompanyTableRowProps {
   index: number;
-  name: string;
-  url?: string;
-  year: number;
+  company: FutureCareers['companies'][number];
 }
 
-function CompanyTableRow({ index, name, url, year }: CompanyTableRowProps) {
+function CompanyTableRow({ index, company }: CompanyTableRowProps) {
+  const [edit, toggleEdit] = useReducer((x) => !x, false);
+
+  return edit ? (
+    <CompanyTableRowEditor index={index} company={company} toggleEdit={toggleEdit} />
+  ) : (
+    <CompanyTableRowViewer index={index} company={company} toggleEdit={toggleEdit} />
+  );
+}
+
+interface CompanyTableRowViewerProps {
+  index: number;
+  company: FutureCareers['companies'][number];
+  toggleEdit: () => void;
+}
+
+function CompanyTableRowViewer({ index, company, toggleEdit }: CompanyTableRowViewerProps) {
+  const { id, name, url, year } = company;
+
+  const handleDelete = async () => {
+    try {
+      handleServerAction(await deleteCareerCompanyAction(id));
+      successToast('졸업생 창업 기업을 삭제했습니다.');
+    } catch (e) {
+      errorToast(errorToStr(e));
+    }
+  };
+
   return (
     <li className="grid grid-cols-[22px,_auto,_1fr] items-center gap-x-1 px-7 py-6 odd:bg-neutral-100 sm:flex sm:h-10 sm:gap-3 sm:p-0 sm:px-3">
       <p className={`text-sm text-neutral-400 sm:pl-2 ${TABLE_COLUMN_SIZE[0]}`}>{index}</p>
-      <p className={`text-md font-medium sm:text-sm sm:font-normal ${TABLE_COLUMN_SIZE[1]}`}>
+      <p
+        className={`text-md font-medium sm:pl-2 sm:text-sm sm:font-normal ${TABLE_COLUMN_SIZE[1]}`}
+      >
         {name}
       </p>
       <a
-        className={`order-last col-span-2 col-start-2 ${
+        className={`order-last col-span-2 col-start-2 sm:pl-2 ${
           url && 'mt-1'
         } w-fit text-xs text-link hover:underline sm:order-none sm:mt-0 ${TABLE_COLUMN_SIZE[2]}
           `}
@@ -60,7 +105,52 @@ function CompanyTableRow({ index, name, url, year }: CompanyTableRowProps) {
       >
         {url}
       </a>
-      <p className={`pl-1 text-sm text-neutral-400 ${TABLE_COLUMN_SIZE[3]}`}>{year}</p>
+      <p className={`pl-2 text-sm text-neutral-400 ${TABLE_COLUMN_SIZE[3]}`}>{year}</p>
+      <div className="flex w-32 gap-2">
+        <GrayButton title="편집" onClick={toggleEdit} />
+        {/* TODO: 삭제 확인 알림 띄우기 */}
+        <GrayButton title="삭제" onClick={handleDelete} />
+      </div>
+    </li>
+  );
+}
+
+function CompanyTableRowEditor({ index, company, toggleEdit }: CompanyTableRowViewerProps) {
+  const { content, setContentByKey } = useEditorContent(company);
+
+  const handleSubmit = async () => {
+    try {
+      handleServerAction(await putCareerCompanyAction(content.id, content));
+      toggleEdit();
+      successToast('졸업생 창업 기업을 수정했습니다.');
+    } catch (e) {
+      errorToast(errorToStr(e));
+    }
+  };
+
+  return (
+    <li className="grid grid-cols-[22px,_auto,_1fr] items-center gap-x-1 px-7 py-6 odd:bg-neutral-100 sm:flex sm:h-10 sm:gap-3 sm:p-0 sm:px-3">
+      <p className={`text-sm text-neutral-400 sm:pl-2 ${TABLE_COLUMN_SIZE[0]}`}>{index}</p>
+      <div className={`text-md font-medium sm:text-sm sm:font-normal ${TABLE_COLUMN_SIZE[1]}`}>
+        <BasicTextInput value={content.name} onChange={setContentByKey('name')} maxWidth="w-full" />
+      </div>
+      <div className={`text-md font-medium sm:text-sm sm:font-normal ${TABLE_COLUMN_SIZE[2]}`}>
+        <BasicTextInput
+          value={content.url ?? ''}
+          onChange={setContentByKey('url')}
+          maxWidth="w-full"
+        />
+      </div>
+      <div className={`text-md font-medium sm:text-sm sm:font-normal ${TABLE_COLUMN_SIZE[3]}`}>
+        <BasicTextInput
+          value={content.year.toString()}
+          onChange={(text) => isNumber(text) && setContentByKey('year')(Number(text))}
+          maxWidth="w-full"
+        />
+      </div>
+      <div className="w-32">
+        <BlackButton title="완료" onClick={handleSubmit} />
+      </div>
     </li>
   );
 }

--- a/app/[locale]/about/future-careers/CareerStat.tsx
+++ b/app/[locale]/about/future-careers/CareerStat.tsx
@@ -42,7 +42,7 @@ export default function CareerStat({ stat }: { stat: FutureCareers['stat'] }) {
             <Link href={`${careerPath}/stat/create`}>
               <OrangeButton title="연도 추가" />
             </Link>
-            <EditButton href={`${careerPath}/description/edit`} />
+            <EditButton href={`${careerPath}/stat/edit?year=${year}`} />
           </div>
         </LoginVisible>
       </div>

--- a/app/[locale]/about/future-careers/CareerStat.tsx
+++ b/app/[locale]/about/future-careers/CareerStat.tsx
@@ -19,7 +19,7 @@ export default function CareerStat({ stat }: { stat: FutureCareers['stat'] }) {
   if (yearStat === undefined) return <p>선택된 연도의 자료가 없습니다.</p>;
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="mt-7 flex flex-col gap-3">
       <div className="flex items-center gap-2">
         <h3 className="text-base font-bold">{t('졸업생 진로 현황')}</h3>
         <Dropdown
@@ -28,7 +28,7 @@ export default function CareerStat({ stat }: { stat: FutureCareers['stat'] }) {
           onClick={setIdx}
         />
       </div>
-      <div className="mb-9 flex h-[14rem] flex-col justify-stretch border-y-[1px] border-y-neutral-300 text-xs font-normal sm:w-[432px]">
+      <div className="flex h-[14rem] flex-col justify-stretch border-y-[1px] border-y-neutral-300 text-xs font-normal sm:w-[432px]">
         <TableHeader />
         {careerStatRows.map((company, index) => {
           return (

--- a/app/[locale]/about/future-careers/CareerStat.tsx
+++ b/app/[locale]/about/future-careers/CareerStat.tsx
@@ -3,11 +3,18 @@
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 
+import { EditButton, OrangeButton } from '@/components/common/Buttons';
 import Dropdown from '@/components/common/form/Dropdown';
+import LoginVisible from '@/components/common/LoginVisible';
+import { Link } from '@/navigation';
 import { FutureCareers } from '@/types/about';
+import { getPath } from '@/utils/page';
+import { futureCareers } from '@/utils/segmentNode';
 
-export const careerStatRows = ['삼성', 'LG', '기타 대기업', '중소기업', '진학', '기타'];
-export const careerStatCols = ['학부', '석사', '박사'];
+export const CAREER_STAT_ROWS = ['삼성', 'LG', '기타 대기업', '중소기업', '진학', '기타'];
+export const CAREER_STAT_COLS = ['학부', '석사', '박사'];
+
+const careerPath = getPath(futureCareers);
 
 export default function CareerStat({ stat }: { stat: FutureCareers['stat'] }) {
   const [idx, setIdx] = useState(0);
@@ -20,17 +27,29 @@ export default function CareerStat({ stat }: { stat: FutureCareers['stat'] }) {
 
   return (
     <div className="mt-7 flex flex-col gap-3">
-      <div className="flex items-center gap-2">
-        <h3 className="text-base font-bold">{t('졸업생 진로 현황')}</h3>
-        <Dropdown
-          contents={stat.map((x) => x.year.toString())}
-          selectedIndex={idx}
-          onClick={setIdx}
-        />
+      <div className="flex justify-between sm:w-[432px]">
+        <div className="flex items-center gap-2">
+          <h3 className="text-base font-bold">{t('졸업생 진로 현황')}</h3>
+          <Dropdown
+            contents={stat.map((x) => x.year.toString())}
+            selectedIndex={idx}
+            onClick={setIdx}
+            height="h-9"
+          />
+        </div>
+        <LoginVisible staff>
+          <div className="flex justify-end gap-3">
+            <Link href={`${careerPath}/stat/create`}>
+              <OrangeButton title="연도 추가" />
+            </Link>
+            <EditButton href={`${careerPath}/description/edit`} />
+          </div>
+        </LoginVisible>
       </div>
-      <div className="flex h-[14rem] flex-col justify-stretch border-y-[1px] border-y-neutral-300 text-xs font-normal sm:w-[432px]">
+
+      <div className="border-y-[1px] border-y-neutral-300 text-xs font-normal sm:w-[432px]">
         <TableHeader />
-        {careerStatRows.map((company, index) => {
+        {CAREER_STAT_ROWS.map((company, index) => {
           return (
             <TableRow
               key={index}
@@ -50,9 +69,9 @@ export default function CareerStat({ stat }: { stat: FutureCareers['stat'] }) {
 
 function TableHeader() {
   return (
-    <div className="flex flex-1 border-b border-b-neutral-300 bg-neutral-100">
+    <div className="flex h-8 flex-1 border-b border-b-neutral-300 bg-neutral-100">
       <div className="w-[6.25rem]" />
-      {careerStatCols.map((colName) => (
+      {CAREER_STAT_COLS.map((colName) => (
         <div key={colName} className="flex flex-1 items-center justify-center">
           <p className="text-sm">{colName}</p>
         </div>
@@ -63,7 +82,7 @@ function TableHeader() {
 
 function TableRow({ rowName, values }: { rowName: string; values: number[] }) {
   return (
-    <div className={`flex flex-1 flex-row border-b border-neutral-200 last:border-0`}>
+    <div className={`flex h-8 flex-1 flex-row border-b border-neutral-200 last:border-0`}>
       <div className="flex w-[6.25rem] items-center justify-center bg-neutral-100 text-sm">
         {rowName}
       </div>

--- a/app/[locale]/about/future-careers/description/edit/CareerDescriptionEditContent.tsx
+++ b/app/[locale]/about/future-careers/description/edit/CareerDescriptionEditContent.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { putCareerDescriptionAction } from '@/actions/about';
+import BasicEditor, { BasicEditorContent } from '@/components/editor/BasicEditor';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { useRouter } from '@/navigation';
+import { WithLanguage } from '@/types/language';
+import { errorToStr } from '@/utils/error';
+import { validateBasicForm } from '@/utils/formValidation';
+import { getPath } from '@/utils/page';
+import { studentClubs } from '@/utils/segmentNode';
+import { handleServerAction } from '@/utils/serverActionError';
+import { errorToast, successToast } from '@/utils/toast';
+
+const clubPath = getPath(studentClubs);
+
+export default function CareerDescriptionEditPageContent({ data }: { data: WithLanguage<string> }) {
+  const router = useRouter();
+
+  const handleCancel = () => router.push(clubPath);
+
+  const handleSubmit = async (content: BasicEditorContent) => {
+    validateBasicForm(content);
+
+    const newData = {
+      koDescription: content.description.ko,
+      enDescription: content.description.en,
+    };
+
+    try {
+      handleServerAction(await putCareerDescriptionAction(newData));
+      successToast('졸업생 진로 본문을 수정했습니다.');
+    } catch (e) {
+      errorToast(errorToStr(e));
+    }
+  };
+
+  return (
+    <PageLayout title="졸업생 진로 본문 편집" titleType="big" hideNavbar>
+      <BasicEditor
+        initialContent={{ description: data }}
+        actions={{ type: 'EDIT', onCancel: handleCancel, onSubmit: handleSubmit }}
+        showLanguage
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/about/future-careers/description/edit/page.tsx
+++ b/app/[locale]/about/future-careers/description/edit/page.tsx
@@ -1,0 +1,11 @@
+import { getFutureCareeres } from '@/apis/about';
+
+import CareerDescriptionEditPageContent from './CareerDescriptionEditContent';
+
+export default async function CareerDescriptionEditPage() {
+  const [koData, enData] = await Promise.all([getFutureCareeres('ko'), getFutureCareeres('en')]);
+
+  return (
+    <CareerDescriptionEditPageContent data={{ ko: koData.description, en: enData.description }} />
+  );
+}

--- a/app/[locale]/about/future-careers/page.tsx
+++ b/app/[locale]/about/future-careers/page.tsx
@@ -1,31 +1,35 @@
 export const dynamic = 'force-dynamic';
 
-import { Metadata } from 'next';
-
 import { getFutureCareeres } from '@/apis/about';
+import { EditButton } from '@/components/common/Buttons';
+import LoginVisible from '@/components/common/LoginVisible';
+import HTMLViewer from '@/components/editor/HTMLViewer';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { Language } from '@/types/language';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
 import { futureCareers } from '@/utils/segmentNode';
 
 import CareerCompanies from './CareerCompanies';
 import CareerStat from './CareerStat';
 
-export async function generateMetadata({
-  params: { locale },
-}: {
-  params: { locale: string };
-}): Promise<Metadata> {
+export async function generateMetadata({ params: { locale } }: { params: { locale: Language } }) {
   return await getMetadata({ locale, node: futureCareers });
 }
 
-export default async function GreetingsPage() {
-  const { description, stat, companies } = await getFutureCareeres();
+const careerPath = getPath(futureCareers);
+
+export default async function FutureCareersPage({ params }: { params: { locale: Language } }) {
+  const { description, stat, companies } = await getFutureCareeres(params.locale);
 
   return (
     <PageLayout titleType="big">
-      <p className="mb-9 whitespace-pre-wrap break-keep text-md font-normal leading-[1.625rem]">
-        {description}
-      </p>
+      <HTMLViewer htmlContent={description} />
+      <LoginVisible staff>
+        <div className="flex justify-end">
+          <EditButton href={`${careerPath}/description/edit`} />
+        </div>
+      </LoginVisible>
       <CareerStat stat={stat} />
       <CareerCompanies companies={companies} />
     </PageLayout>

--- a/app/[locale]/about/future-careers/page.tsx
+++ b/app/[locale]/about/future-careers/page.tsx
@@ -24,14 +24,22 @@ export default async function FutureCareersPage({ params }: { params: { locale: 
 
   return (
     <PageLayout titleType="big">
-      <HTMLViewer htmlContent={description} />
-      <LoginVisible staff>
-        <div className="flex justify-end">
-          <EditButton href={`${careerPath}/description/edit`} />
-        </div>
-      </LoginVisible>
+      <CareerDescription description={description} />
       <CareerStat stat={stat} />
       <CareerCompanies companies={companies} />
     </PageLayout>
+  );
+}
+
+function CareerDescription({ description }: { description: string }) {
+  return (
+    <>
+      <HTMLViewer htmlContent={description} />
+      <LoginVisible staff>
+        <div className="flex justify-end pb-2">
+          <EditButton href={`${careerPath}/description/edit`} />
+        </div>
+      </LoginVisible>
+    </>
   );
 }

--- a/app/[locale]/about/future-careers/stat/create/page.tsx
+++ b/app/[locale]/about/future-careers/stat/create/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { postCareerStatAction } from '@/actions/about';
+import CareerStatEditor, { CareerStatEditorContent } from '@/components/editor/CareerStatEditor';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { useRouter } from '@/navigation';
+import { errorToStr } from '@/utils/error';
+import { getPath } from '@/utils/page';
+import { studentClubs } from '@/utils/segmentNode';
+import { handleServerAction } from '@/utils/serverActionError';
+import { errorToast, successToast } from '@/utils/toast';
+
+const clubPath = getPath(studentClubs);
+
+export default function CareerStatCreatePage() {
+  const router = useRouter();
+
+  const handleCancel = () => router.push(clubPath);
+
+  const handleSubmit = async (content: CareerStatEditorContent) => {
+    try {
+      handleServerAction(await postCareerStatAction(content));
+      successToast('졸업생 진로 현황을 추가했습니다.');
+    } catch (e) {
+      errorToast(errorToStr(e));
+    }
+  };
+
+  return (
+    <PageLayout title="졸업생 진로 현황 추가" titleType="big" hideNavbar>
+      <CareerStatEditor
+        actions={{ type: 'EDIT', onCancel: handleCancel, onSubmit: handleSubmit }}
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/about/future-careers/stat/edit/CareerStatEditPageContent.tsx
+++ b/app/[locale]/about/future-careers/stat/edit/CareerStatEditPageContent.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { postCareerStatAction } from '@/actions/about';
+import { putCareerStatAction } from '@/actions/about';
 import CareerStatEditor, { CareerStatEditorContent } from '@/components/editor/CareerStatEditor';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { useRouter } from '@/navigation';
+import { FutureCareers } from '@/types/about';
 import { errorToStr } from '@/utils/error';
 import { getPath } from '@/utils/page';
 import { futureCareers } from '@/utils/segmentNode';
@@ -12,23 +13,28 @@ import { errorToast, successToast } from '@/utils/toast';
 
 const careerPath = getPath(futureCareers);
 
-export default function CareerStatCreatePage() {
+export default function CareerStatEditPageContent({
+  data,
+}: {
+  data: FutureCareers['stat'][number];
+}) {
   const router = useRouter();
 
   const handleCancel = () => router.push(careerPath);
 
   const handleSubmit = async (content: CareerStatEditorContent) => {
     try {
-      handleServerAction(await postCareerStatAction(content));
-      successToast('졸업생 진로 현황을 추가했습니다.');
+      handleServerAction(await putCareerStatAction(content));
+      successToast('졸업생 진로 현황을 수정했습니다.');
     } catch (e) {
       errorToast(errorToStr(e));
     }
   };
 
   return (
-    <PageLayout title="졸업생 진로 현황 추가" titleType="big" hideNavbar>
+    <PageLayout title={`${data.year}년 졸업생 진로 현황 편집`} titleType="big" hideNavbar>
       <CareerStatEditor
+        initialContent={data}
         actions={{ type: 'EDIT', onCancel: handleCancel, onSubmit: handleSubmit }}
       />
     </PageLayout>

--- a/app/[locale]/about/future-careers/stat/edit/page.tsx
+++ b/app/[locale]/about/future-careers/stat/edit/page.tsx
@@ -1,0 +1,19 @@
+import { getFutureCareeres } from '@/apis/about';
+import { Language } from '@/types/language';
+
+import CareerStatEditPageContent from './CareerStatEditPageContent';
+
+interface CareerStatEditPageProps {
+  params: { locale: Language };
+  searchParams: { year: string };
+}
+
+export default async function CareerStatEditPage({
+  params,
+  searchParams,
+}: CareerStatEditPageProps) {
+  const { stat } = await getFutureCareeres(params.locale);
+  const selectedStat = stat.find((x) => x.year.toString() === searchParams.year) ?? stat[0];
+
+  return <CareerStatEditPageContent data={selectedStat} />;
+}

--- a/app/[locale]/academics/helper/timeline/TimelineEditor.tsx
+++ b/app/[locale]/academics/helper/timeline/TimelineEditor.tsx
@@ -6,6 +6,7 @@ import BasicEditor from '@/components/editor/BasicEditor';
 import BasicTextInput from '@/components/editor/common/BasicTextInput';
 import Fieldset from '@/components/editor/common/Fieldset';
 import { useRouter } from '@/navigation';
+import { isNumber } from '@/utils/number';
 import { CustomError, handleServerAction } from '@/utils/serverActionError';
 import { errorToast, successToast } from '@/utils/toast';
 
@@ -60,8 +61,6 @@ export default function TimelineEditor({
   );
 }
 
-const NUMBER_REGEX = /^\d*$/;
-
 function YearFieldset({
   year,
   onChange,
@@ -71,8 +70,6 @@ function YearFieldset({
   onChange: (value: number) => void;
   disabled?: boolean;
 }) {
-  const isNumber = (value: string) => NUMBER_REGEX.test(value);
-
   return (
     <Fieldset title="연도" mb="mb-6" titleMb="mb-2">
       <BasicTextInput

--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -17,7 +17,7 @@ export function GrayButton({
 }) {
   return (
     <button
-      className={`rounded-[.0625rem] border-[1px] border-neutral-200 bg-neutral-100 px-[.875rem] py-[.3125rem] text-md font-medium leading-[1.5rem] text-neutral-500 enabled:hover:bg-neutral-200 ${
+      className={`whitespace-nowrap rounded-[.0625rem] border-[1px] border-neutral-200 bg-neutral-100 px-[.875rem] py-[.3125rem] text-md font-medium leading-[1.5rem] text-neutral-500 enabled:hover:bg-neutral-200 ${
         disabled && 'opacity-30'
       }`}
       disabled={disabled}
@@ -39,7 +39,7 @@ export function BlackButton({
 }) {
   return (
     <button
-      className={`rounded-[.0625rem] bg-neutral-700 px-[.875rem] py-[.34rem] text-xs font-bold leading-[1.5rem] text-white enabled:hover:bg-neutral-500 ${
+      className={`whitespace-nowrap rounded-[.0625rem] bg-neutral-700 px-[.875rem] py-[.3125rem] text-md font-semibold leading-[1.5rem] text-white enabled:hover:bg-neutral-500 ${
         disabled && 'opacity-30'
       }`}
       disabled={disabled}

--- a/components/editor/CareerStatEditor.tsx
+++ b/components/editor/CareerStatEditor.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useState } from 'react';
+
+import { FutureCareers } from '@/types/about';
+import { getKeys } from '@/types/object';
+import { isNumber } from '@/utils/number';
+
+import { EditAction, EditActionButtons } from './common/ActionButtons';
+import BasicTextInput from './common/BasicTextInput';
+import Fieldset from './common/Fieldset';
+
+interface Stat {
+  career: COMPANY;
+  bachelor: number;
+  master: number;
+  doctor: number;
+}
+
+export interface CareerStatEditorContent {
+  year: number;
+  statList: Stat[];
+}
+
+interface CareerStatEditorProps {
+  initialContent?: FutureCareers['stat'][number];
+  actions: EditAction<CareerStatEditorContent>;
+}
+
+const COMPANY_MAP = {
+  SAMSUNG: '삼성',
+  LG: 'LG',
+  LARGE: '기타 대기업',
+  SMALL: '중소기업',
+  GRADUATE: '진학',
+  OTHER: '기타',
+} as const;
+
+const DEGREE_MAP = {
+  bachelor: '학부',
+  master: '석사',
+  doctor: '박사',
+} as const;
+
+type COMPANY = keyof typeof COMPANY_MAP;
+type DEGREE = keyof typeof DEGREE_MAP;
+
+const CAREER_COMPANIES = getKeys(COMPANY_MAP);
+const CAREER_DEGREES = getKeys(DEGREE_MAP);
+
+const getNextYear = () => new Date().getFullYear() + 1;
+
+export default function CareerStatEditor({ actions, initialContent }: CareerStatEditorProps) {
+  const [year, setYear] = useState<number>(initialContent?.year ?? getNextYear());
+  const [stats, setStats] = useState<Stat[]>(getInitialStats(initialContent));
+
+  const handleStatChange = (company: COMPANY, degree: DEGREE, count: number) => {
+    setStats((prev) =>
+      prev.map((stat) => (stat.career === company ? { ...stat, [degree]: count } : stat)),
+    );
+  };
+
+  return (
+    <form className="flex flex-col">
+      <YearFieldset year={year} onChange={setYear} disabled={Boolean(initialContent)} />
+      <div className="border-y-[1px] border-y-neutral-300 text-xs font-normal sm:w-[432px]">
+        <TableHeader />
+        {stats.map((stat, index) => {
+          return (
+            <TableRow
+              key={index}
+              company={stat.career}
+              stats={[
+                { degree: 'bachelor', count: stat.bachelor },
+                { degree: 'master', count: stat.master },
+                { degree: 'doctor', count: stat.doctor },
+              ]}
+              onChange={handleStatChange}
+            />
+          );
+        })}
+      </div>
+      <div className="mt-5 flex gap-3 self-end">
+        {actions.type === 'EDIT' && (
+          <EditActionButtons {...actions} getContent={() => ({ year: year, statList: stats })} />
+        )}
+      </div>
+    </form>
+  );
+}
+
+function YearFieldset({
+  year,
+  onChange,
+  disabled = false,
+}: {
+  year: number;
+  onChange: (value: number) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Fieldset title="연도" mb="mb-6" titleMb="mb-2">
+      <BasicTextInput
+        value={year.toString()}
+        onChange={(text) => isNumber(text) && onChange(Number(text))}
+        maxWidth="w-[55px]"
+        disabled={disabled}
+      />
+    </Fieldset>
+  );
+}
+
+function TableHeader() {
+  return (
+    <div className="flex h-9 flex-1 border-b border-b-neutral-300 bg-neutral-100">
+      <div className="w-[6.25rem]" />
+      {CAREER_DEGREES.map((degree) => (
+        <div key={degree} className="flex flex-1 items-center justify-center">
+          <p className="text-sm">{DEGREE_MAP[degree]}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TableRow({
+  company,
+  stats,
+  onChange,
+}: {
+  company: COMPANY;
+  stats: { degree: DEGREE; count: number }[];
+  onChange: (company: COMPANY, degree: DEGREE, count: number) => void;
+}) {
+  return (
+    <div className={`flex flex-1 flex-row border-b border-neutral-200 last:border-0`}>
+      <div className="flex w-[6.25rem] items-center justify-center bg-neutral-100 text-sm">
+        {COMPANY_MAP[company]}
+      </div>
+      {stats.map((stat) => (
+        <div key={stat.degree} className="flex flex-1 items-center justify-center py-1.5 text-md">
+          <BasicTextInput
+            value={stat.count.toString()}
+            onChange={(text) => isNumber(text) && onChange(company, stat.degree, Number(text))}
+            maxWidth="max-w-[80px]"
+            textCenter
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const DEFAULT_STATS = CAREER_COMPANIES.map((company) => ({
+  career: company,
+  bachelor: 0,
+  master: 0,
+  doctor: 0,
+}));
+
+const refinedStats = (initStats: FutureCareers['stat'][number]) => {
+  const values = CAREER_COMPANIES.map((company) => ({
+    career: company,
+    bachelor: initStats.bachelor.find((x) => x.name === COMPANY_MAP[company])?.count ?? 0,
+    master: initStats.master.find((x) => x.name === COMPANY_MAP[company])?.count ?? 0,
+    doctor: initStats.doctor.find((x) => x.name === COMPANY_MAP[company])?.count ?? 0,
+  }));
+
+  return values;
+};
+
+const getInitialStats = (initStats?: FutureCareers['stat'][number]) => {
+  return initStats ? refinedStats(initStats) : DEFAULT_STATS;
+};

--- a/components/editor/common/ActionButtons.tsx
+++ b/components/editor/common/ActionButtons.tsx
@@ -91,7 +91,7 @@ export function CreateActionButtons<T>({
   );
 }
 
-const buildPostHandler = <T,>(
+export const buildPostHandler = <T,>(
   requesting: boolean,
   setRequesting: (val: boolean) => void,
   getContent: () => T,

--- a/components/editor/common/BasicTextInput.tsx
+++ b/components/editor/common/BasicTextInput.tsx
@@ -5,6 +5,7 @@ export interface BasicTextInputProps {
   placeholder?: string;
   disabled?: boolean;
   bgColor?: string;
+  textCenter?: boolean;
 }
 
 export default function BasicTextInput({
@@ -14,12 +15,15 @@ export default function BasicTextInput({
   maxWidth,
   disabled,
   bgColor = 'bg-white',
+  textCenter,
 }: BasicTextInputProps) {
   return (
     <input
       type="text"
       className={`${maxWidth} autofill-bg-white h-8 rounded-sm border border-neutral-300
-            ${bgColor} pl-2 text-sm outline-none placeholder:text-neutral-300 disabled:text-neutral-400`}
+            ${bgColor} pl-2 text-sm outline-none placeholder:text-neutral-300 disabled:text-neutral-400 ${
+              textCenter && 'pr-2 text-center'
+            }`}
       placeholder={placeholder}
       value={value ?? ''}
       onChange={(e) => onChange(e.target.value)}

--- a/components/modal/AlertModal.tsx
+++ b/components/modal/AlertModal.tsx
@@ -4,6 +4,7 @@ import { useFormStatus } from 'react-dom';
 
 import useModal from '@/utils/hooks/useModal';
 
+import { GrayButton } from '../common/Buttons';
 import ModalFrame from './ModalFrame';
 
 interface AlertModalProps {
@@ -34,8 +35,8 @@ export default function AlertModal({
       >
         <AlertMessage message={message} />
         <div className="text-right">
-          <CancelButton
-            text={cancelText}
+          <GrayButton
+            title={cancelText}
             onClick={() => {
               onCancel?.();
               closeModal();
@@ -50,18 +51,6 @@ export default function AlertModal({
 
 function AlertMessage({ message }: { message: string }) {
   return <p className="mb-6 mt-1 text-neutral-800">{message}</p>;
-}
-
-function CancelButton({ text, onClick }: { text: string; onClick: () => void }) {
-  return (
-    <button
-      className={`h-[2.1875rem] rounded-[.0625rem] border border-neutral-200 bg-neutral-100 px-[17px] text-xs font-bold text-neutral-500 hover:bg-neutral-200 hover:text-neutral-700`}
-      onClick={onClick}
-      type="button"
-    >
-      {text}
-    </button>
-  );
 }
 
 function ConfirmButton({ text }: { text: string }) {

--- a/constants/network.ts
+++ b/constants/network.ts
@@ -33,6 +33,7 @@ export const FETCH_TAG_CLUB = 'club';
 export const FETCH_TAG_FACILITIES = 'facilities';
 export const FETCH_TAG_CONTACT = 'contact';
 export const FETCH_TAG_DIRECTIONS = 'directions';
+export const FETCH_TAG_CAREER = 'career';
 
 export const FETCH_TAG_GROUP = 'group';
 export const FETCH_TAG_CENTER = 'center';

--- a/constants/network.ts
+++ b/constants/network.ts
@@ -32,6 +32,7 @@ export const FETCH_TAG_HISTORY = 'history';
 export const FETCH_TAG_CLUB = 'club';
 export const FETCH_TAG_FACILITIES = 'facilities';
 export const FETCH_TAG_CONTACT = 'contact';
+export const FETCH_TAG_DIRECTIONS = 'directions';
 
 export const FETCH_TAG_GROUP = 'group';
 export const FETCH_TAG_CENTER = 'center';

--- a/types/about.ts
+++ b/types/about.ts
@@ -15,6 +15,7 @@ export interface FutureCareers {
     doctor: { name: string; count: number }[];
   }[];
   companies: {
+    id: number;
     name: string;
     url?: string;
     year: number;

--- a/types/about.ts
+++ b/types/about.ts
@@ -36,12 +36,8 @@ export interface Facility {
   imageURL: string | null;
 }
 
-export interface Contact {
-  description: string;
-  imageURL: string;
-}
-
 export interface Direction {
+  id: number;
   name: string;
   description: string;
 }

--- a/utils/formValidation.ts
+++ b/utils/formValidation.ts
@@ -1,3 +1,4 @@
+import { CareerCompanyEditorContent } from '@/app/[locale]/about/future-careers/CareerCompanies';
 import { BasicEditorContent } from '@/components/editor/BasicEditor';
 import { FacilityEditorContent } from '@/components/editor/FacilityEditor';
 import { FacultyEditorContent } from '@/components/editor/FacultyEditor';
@@ -115,5 +116,14 @@ export const validateFacilityForm = (content: WithLanguage<FacilityEditorContent
     Object.entries(content.en).some(([key, value]) => key !== 'mainImage' && isValueEmpty(value))
   ) {
     throw new Error('영문 정보도 입력해주세요');
+  }
+};
+
+export const validateCareerCompanyForm = (content: CareerCompanyEditorContent) => {
+  if (!content.name) {
+    throw new Error('기업명을 입력해주세요');
+  }
+  if (!content.year) {
+    throw new Error('창업 연도를 입력해주세요');
   }
 };

--- a/utils/number.ts
+++ b/utils/number.ts
@@ -1,0 +1,2 @@
+const NUMBER_REGEX = /^\d*$/;
+export const isNumber = (value: string) => NUMBER_REGEX.test(value);


### PR DESCRIPTION
- 시설 안내 수정 기능 추가
- 찾아오는 길 수정/삭제 기능 추가
- 졸업생 진로 편집 기능 추가
  - 본문 수정
  - 진로 현황 추가/수정
  - 창업 기업 추가/수정/삭제
- 전반적인 로직은 다른 페이지들 편집과 유사함
- 찾아오는 길 제목 하드코딩되어 있던 것(대중교통'으로', 승용차'로', 해외'에서') 제거하고 제목 키워드만 담는 것으로 변경
  - 영문까지 고려할 방법이 마땅치 않았음