### PR TITLE
✨ 학사 및 교과 타임라인 본문 첨부파일 추가

### DIFF
--- a/actions/academics.ts
+++ b/actions/academics.ts
@@ -32,14 +32,7 @@ import {
   FETCH_TAG_SCHOLARSHIP,
 } from '@/constants/network';
 import { redirect } from '@/navigation';
-import {
-  Course,
-  CourseChange,
-  Curriculum,
-  GeneralStudiesRequirement,
-  Scholarship,
-  StudentType,
-} from '@/types/academics';
+import { Course, Scholarship, StudentType } from '@/types/academics';
 import { WithLanguage } from '@/types/language';
 import { getPath } from '@/utils/page';
 import { graduateScholarship, undergraduateScholarship } from '@/utils/segmentNode';
@@ -72,13 +65,15 @@ export const deleteCourseAction = withErrorHandler(async (code: string) => {
 
 /** 전공 이수 표준 형태 */
 
-export const postCurriculumAction = withErrorHandler(async (data: Curriculum) => {
-  await postCurriculum(data);
+export const postCurriculumAction = withErrorHandler(async (formData: FormData) => {
+  decodeFormDataFileName(formData, 'attachments');
+  await postCurriculum(formData);
   revalidateTag(FETCH_TAG_CURRICULUM);
 });
 
-export const putCurriculumAction = withErrorHandler(async (data: Curriculum) => {
-  await putCurriculum(data);
+export const putCurriculumAction = withErrorHandler(async (year: number, formData: FormData) => {
+  decodeFormDataFileName(formData, 'newAttachments');
+  await putCurriculum(year, formData);
   revalidateTag(FETCH_TAG_CURRICULUM);
 });
 
@@ -89,17 +84,19 @@ export const deleteCurriculumAction = withErrorHandler(async (year: number) => {
 
 /** 필수 교양 과목 */
 
-export const postGeneralStudiesAction = withErrorHandler(
-  async (data: GeneralStudiesRequirement) => {
-    await postGeneralStudies(data);
+export const postGeneralStudiesAction = withErrorHandler(async (formData: FormData) => {
+  decodeFormDataFileName(formData, 'attachments');
+  await postGeneralStudies(formData);
+  revalidateTag(FETCH_TAG_GENERAL_STUDIES);
+});
+
+export const putGeneralStudiesAction = withErrorHandler(
+  async (year: number, formData: FormData) => {
+    decodeFormDataFileName(formData, 'newAttachments');
+    await putGeneralStudies(year, formData);
     revalidateTag(FETCH_TAG_GENERAL_STUDIES);
   },
 );
-
-export const putGeneralStudiesAction = withErrorHandler(async (data: GeneralStudiesRequirement) => {
-  await putGeneralStudies(data);
-  revalidateTag(FETCH_TAG_GENERAL_STUDIES);
-});
 
 export const deleteGeneralStudiesAction = withErrorHandler(async (year: number) => {
   await deleteGeneralStudies(year);
@@ -117,15 +114,17 @@ export const putDegreeRequirementsAction = withErrorHandler(async (formData: For
 /** 교과목 변경 내역 */
 
 export const postCourseChangesAction = withErrorHandler(
-  async (type: StudentType, data: CourseChange) => {
-    await postCourseChanges(type, data);
+  async (type: StudentType, formData: FormData) => {
+    decodeFormDataFileName(formData, 'attachments');
+    await postCourseChanges(type, formData);
     revalidateTag(FETCH_TAG_COURSE_CHANGES);
   },
 );
 
 export const putCourseChangesAction = withErrorHandler(
-  async (type: StudentType, data: CourseChange) => {
-    await putCourseChanges(type, data);
+  async (type: StudentType, year: number, formData: FormData) => {
+    decodeFormDataFileName(formData, 'newAttachments');
+    await putCourseChanges(type, year, formData);
     revalidateTag(FETCH_TAG_COURSE_CHANGES);
   },
 );

--- a/apis/academics.ts
+++ b/apis/academics.ts
@@ -9,15 +9,13 @@ import {
 } from '@/constants/network';
 import {
   Course,
-  CourseChange,
-  Curriculum,
   DegreeRequirements,
-  GeneralStudiesRequirement,
   GeneralStudiesRequirements,
   Guide,
   Scholarship,
   ScholarshipList,
   StudentType,
+  TimelineContent,
 } from '@/types/academics';
 import { Language, WithLanguage } from '@/types/language';
 
@@ -71,23 +69,15 @@ export const deleteCourse = async (code: string) =>
 const curriculumUrl = '/academics/undergraduate/curriculum';
 
 export const getCurriculum = () =>
-  getRequest<Curriculum[]>(curriculumUrl, undefined, {
+  getRequest<TimelineContent[]>(curriculumUrl, undefined, {
     next: { tags: [FETCH_TAG_CURRICULUM] },
   });
 
-export const postCurriculum = (data: Curriculum) =>
-  postRequest(curriculumUrl, {
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...data, name: '전공 이수 표준 형태' }),
-    jsessionID: true,
-  });
+export const postCurriculum = (formData: FormData) =>
+  postRequest(curriculumUrl, { body: formData, jsessionID: true });
 
-export const putCurriculum = (data: Curriculum) =>
-  putRequest(`${curriculumUrl}/${data.year}`, {
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ description: data.description }),
-    jsessionID: true,
-  });
+export const putCurriculum = (year: number, formData: FormData) =>
+  putRequest(`${curriculumUrl}/${year}`, { body: formData, jsessionID: true });
 
 export const deleteCurriculum = async (year: number) =>
   deleteRequest(`${curriculumUrl}/${year}`, { jsessionID: true });
@@ -101,19 +91,11 @@ export const getGeneralStudies = () =>
     next: { tags: [FETCH_TAG_GENERAL_STUDIES] },
   });
 
-export const postGeneralStudies = (data: GeneralStudiesRequirement) =>
-  postRequest(generalStudiesUrl, {
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...data, name: '필수 교양 과목' }),
-    jsessionID: true,
-  });
+export const postGeneralStudies = (formData: FormData) =>
+  postRequest(generalStudiesUrl, { body: formData, jsessionID: true });
 
-export const putGeneralStudies = (data: GeneralStudiesRequirement) =>
-  putRequest(`${generalStudiesUrl}/${data.year}`, {
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ description: data.description }),
-    jsessionID: true,
-  });
+export const putGeneralStudies = (year: number, formData: FormData) =>
+  putRequest(`${generalStudiesUrl}/${year}`, { body: formData, jsessionID: true });
 
 export const deleteGeneralStudies = async (year: number) =>
   deleteRequest(`${generalStudiesUrl}/${year}`, {
@@ -133,23 +115,15 @@ export const putDegreeRequirements = (formData: FormData) =>
 /** 교과목 변경 내역 */
 
 export const getCourseChanges = (type: StudentType) =>
-  getRequest<CourseChange[]>(`/academics/${type}/course-changes`, undefined, {
+  getRequest<TimelineContent[]>(`/academics/${type}/course-changes`, undefined, {
     next: { tags: [FETCH_TAG_COURSE_CHANGES] },
   });
 
-export const postCourseChanges = (type: StudentType, data: CourseChange) =>
-  postRequest(`/academics/${type}/course-changes`, {
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...data, name: '교과목 변경 내역' }),
-    jsessionID: true,
-  });
+export const postCourseChanges = (type: StudentType, formData: FormData) =>
+  postRequest(`/academics/${type}/course-changes`, { body: formData, jsessionID: true });
 
-export const putCourseChanges = (type: StudentType, data: CourseChange) =>
-  putRequest(`/academics/${type}/course-changes/${data.year}`, {
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ description: data.description }),
-    jsessionID: true,
-  });
+export const putCourseChanges = (type: StudentType, year: number, formData: FormData) =>
+  putRequest(`/academics/${type}/course-changes/${year}`, { body: formData, jsessionID: true });
 
 export const deleteCourseChanges = async (type: StudentType, year: number) =>
   deleteRequest(`/academics/${type}/course-changes/${year}`, {

--- a/app/[locale]/academics/graduate/course-changes/create/page.tsx
+++ b/app/[locale]/academics/graduate/course-changes/create/page.tsx
@@ -13,8 +13,9 @@ export default function GraduateCourseChangesCreatePage() {
   return (
     <PageLayout title="대학원 교과목 변경 내역 추가" titleType="big">
       <TimelineEditor
-        submitAction={(data) => postCourseChangesAction('graduate', data)}
+        submitAction={(_, formData) => postCourseChangesAction('graduate', formData)}
         fallbackPathname={courseChangesPath}
+        pageName="교과목 변경 내역"
       />
     </PageLayout>
   );

--- a/app/[locale]/academics/helper/course-changes/CourseChangeEditPageContent.tsx
+++ b/app/[locale]/academics/helper/course-changes/CourseChangeEditPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { putCourseChangesAction } from '@/actions/academics';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { CourseChange, StudentType } from '@/types/academics';
+import { StudentType, TimelineContent } from '@/types/academics';
 
 import TimelineEditor from '../timeline/TimelineEditor';
 
@@ -12,7 +12,7 @@ export default function CourseChangesEditPageContent({
   courseChangePath,
 }: {
   type: StudentType;
-  initContent: CourseChange;
+  initContent: TimelineContent;
   courseChangePath: string;
 }) {
   return (
@@ -21,7 +21,7 @@ export default function CourseChangesEditPageContent({
       titleType="big"
     >
       <TimelineEditor
-        submitAction={(data) => putCourseChangesAction(type, data)}
+        submitAction={(year, formData) => putCourseChangesAction(type, year, formData)}
         fallbackPathname={courseChangePath}
         initialContent={initContent}
       />

--- a/app/[locale]/academics/helper/course-changes/CourseChangesPageContent.tsx
+++ b/app/[locale]/academics/helper/course-changes/CourseChangesPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { deleteCourseChangesAction } from '@/actions/academics';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { CourseChange, StudentType } from '@/types/academics';
+import { StudentType, TimelineContent } from '@/types/academics';
 
 import TimelineViewer from '../timeline/TimelineViewer';
 
@@ -11,7 +11,7 @@ export default function CourseChangesPageContent({
   changes,
 }: {
   type: StudentType;
-  changes: CourseChange[];
+  changes: TimelineContent[];
 }) {
   return (
     <PageLayout titleType="big">

--- a/app/[locale]/academics/helper/timeline/TimelineEditor.tsx
+++ b/app/[locale]/academics/helper/timeline/TimelineEditor.tsx
@@ -7,6 +7,7 @@ import BasicEditor, { BasicEditorContent } from '@/components/editor/BasicEditor
 import BasicTextInput from '@/components/editor/common/BasicTextInput';
 import Fieldset from '@/components/editor/common/Fieldset';
 import { useRouter } from '@/navigation';
+import { TimelineContent } from '@/types/academics';
 import { errorToStr } from '@/utils/error';
 import { contentToFormData, getAttachmentDeleteIds } from '@/utils/formData';
 import { isNumber } from '@/utils/number';
@@ -14,7 +15,7 @@ import { CustomError, handleServerAction } from '@/utils/serverActionError';
 import { errorToast, successToast } from '@/utils/toast';
 
 interface TimelineEditorProps {
-  initialContent?: { year: number; description: string; attachments: Attachment[] };
+  initialContent?: TimelineContent;
   submitAction: (year: number, formData: FormData) => Promise<CustomError | void>;
   fallbackPathname: string;
   pageName?: string;

--- a/app/[locale]/academics/helper/timeline/TimelineEditor.tsx
+++ b/app/[locale]/academics/helper/timeline/TimelineEditor.tsx
@@ -2,42 +2,54 @@
 
 import { useState } from 'react';
 
-import BasicEditor from '@/components/editor/BasicEditor';
+import { Attachment } from '@/components/common/Attachments';
+import BasicEditor, { BasicEditorContent } from '@/components/editor/BasicEditor';
 import BasicTextInput from '@/components/editor/common/BasicTextInput';
 import Fieldset from '@/components/editor/common/Fieldset';
 import { useRouter } from '@/navigation';
 import { errorToStr } from '@/utils/error';
+import { contentToFormData, getAttachmentDeleteIds } from '@/utils/formData';
 import { isNumber } from '@/utils/number';
 import { CustomError, handleServerAction } from '@/utils/serverActionError';
 import { errorToast, successToast } from '@/utils/toast';
 
 interface TimelineEditorProps {
-  initialContent?: { year: number; description: string };
-  submitAction: (data: TimelineContent) => Promise<CustomError | void>;
+  initialContent?: { year: number; description: string; attachments: Attachment[] };
+  submitAction: (year: number, formData: FormData) => Promise<CustomError | void>;
   fallbackPathname: string;
+  pageName?: string;
 }
 
 const getNextYear = () => new Date().getFullYear() + 1;
-
-type TimelineContent = { year: number; description: string };
 
 export default function TimelineEditor({
   initialContent,
   submitAction,
   fallbackPathname,
+  pageName,
 }: TimelineEditorProps) {
   const [newYear, setNewYear] = useState<number>(initialContent?.year ?? getNextYear());
   const router = useRouter();
 
   const goToOriginalPage = () => router.push(fallbackPathname);
 
-  const handleSubmit = async (description: string) => {
-    if (!description) {
+  const handleSubmit = async (content: BasicEditorContent) => {
+    if (!content.description) {
       throw new Error('내용을 입력해주세요');
     }
 
+    const formData = initialContent
+      ? contentToFormData('EDIT', {
+          requestObject: getEditRequestObject(content, initialContent.attachments),
+          attachments: content.attachments,
+        })
+      : contentToFormData('CREATE', {
+          requestObject: getCreateRequestObject(newYear, pageName ?? '', content),
+          attachments: content.attachments,
+        });
+
     try {
-      handleServerAction(await submitAction({ description, year: newYear }));
+      handleServerAction(await submitAction(newYear, formData));
       successToast('저장했습니다.');
       goToOriginalPage();
     } catch (e) {
@@ -51,12 +63,14 @@ export default function TimelineEditor({
       <BasicEditor
         initialContent={{
           description: { ko: initialContent?.description ?? '', en: '' },
+          attachments: initialContent?.attachments.map((file) => ({ type: 'UPLOADED_FILE', file })),
         }}
         actions={{
           type: 'EDIT',
           onCancel: goToOriginalPage,
-          onSubmit: (content) => handleSubmit(content.description.ko),
+          onSubmit: handleSubmit,
         }}
+        showAttachments
       />
     </div>
   );
@@ -82,3 +96,23 @@ function YearFieldset({
     </Fieldset>
   );
 }
+
+const getCreateRequestObject = (year: number, name: string, newContent: BasicEditorContent) => {
+  return {
+    year,
+    name,
+    description: newContent.description.ko,
+  };
+};
+
+const getEditRequestObject = (newContent: BasicEditorContent, prevAttachments: Attachment[]) => {
+  const deleteIds = getAttachmentDeleteIds(
+    newContent.attachments,
+    prevAttachments.map((x) => x.id),
+  );
+
+  return {
+    description: newContent.description.ko,
+    deleteIds,
+  };
+};

--- a/app/[locale]/academics/helper/timeline/TimelineViewer.tsx
+++ b/app/[locale]/academics/helper/timeline/TimelineViewer.tsx
@@ -7,6 +7,7 @@ import { DeleteButton, EditButton } from '@/components/common/Buttons';
 import LoginVisible from '@/components/common/LoginVisible';
 import HTMLViewer from '@/components/editor/HTMLViewer';
 import { Link, usePathname } from '@/navigation';
+import { TimelineContent } from '@/types/academics';
 import { errorToStr } from '@/utils/error';
 import { refreshPage } from '@/utils/refreshPage';
 import { CustomError, handleServerAction } from '@/utils/serverActionError';
@@ -21,9 +22,12 @@ interface TimelineViewerProps<T> {
   yearLimitCount?: number;
 }
 
-export default function TimelineViewer<
-  T extends { year: number; description: string; attachments: Attachment[] },
->({ contents, title, deleteAction, yearLimitCount = 10 }: TimelineViewerProps<T>) {
+export default function TimelineViewer<T extends TimelineContent>({
+  contents,
+  title,
+  deleteAction,
+  yearLimitCount = 10,
+}: TimelineViewerProps<T>) {
   const [selectedYear, setSelectedYear] = useState(contents[0].year);
   const timeLineYears = contents.map((change) => change.year).slice(0, yearLimitCount);
   const yearLimit = timeLineYears.at(-1) ?? 0;
@@ -174,9 +178,7 @@ function ContentHTMLViewer({ description }: { description: string }) {
   return <HTMLViewer htmlContent={description} className="bg-neutral-75 p-5" />;
 }
 
-const getSelectedContents = <
-  T extends { year: number; description: string; attachments: Attachment[] },
->(
+const getSelectedContents = <T extends TimelineContent>(
   year: number,
   yearLimit: number,
   data: T[],

--- a/app/[locale]/academics/undergraduate/course-changes/create/page.tsx
+++ b/app/[locale]/academics/undergraduate/course-changes/create/page.tsx
@@ -13,8 +13,9 @@ export default function UndergraduateCourseChangesCreatePage() {
   return (
     <PageLayout title="학부 교과목 변경 내역 추가" titleType="big">
       <TimelineEditor
-        submitAction={(data) => postCourseChangesAction('undergraduate', data)}
+        submitAction={(_, formData) => postCourseChangesAction('undergraduate', formData)}
         fallbackPathname={courseChangesPath}
+        pageName="교과목 변경 내역"
       />
     </PageLayout>
   );

--- a/app/[locale]/academics/undergraduate/course-changes/edit/page.tsx
+++ b/app/[locale]/academics/undergraduate/course-changes/edit/page.tsx
@@ -14,7 +14,6 @@ export default async function UndergraduateCourseChangesEditPage({
   const data = await getCourseChanges('undergraduate');
   const year = Number(searchParams.year);
   const selected = data.find((x) => x.year === year);
-
   if (!selected) {
     return <div>해당 연도 내용이 존재하지 않습니다.</div>;
   }

--- a/app/[locale]/academics/undergraduate/curriculum/CurriculumPageContent.tsx
+++ b/app/[locale]/academics/undergraduate/curriculum/CurriculumPageContent.tsx
@@ -2,11 +2,11 @@
 
 import { deleteCurriculumAction } from '@/actions/academics';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { Curriculum } from '@/types/academics';
+import { TimelineContent } from '@/types/academics';
 
 import TimelineViewer from '../../helper/timeline/TimelineViewer';
 
-export default function CurriculumPageContent({ data }: { data: Curriculum[] }) {
+export default function CurriculumPageContent({ data }: { data: TimelineContent[] }) {
   return (
     <PageLayout titleType="big">
       {/* 추후 RoadMapButton 복구 */}

--- a/app/[locale]/academics/undergraduate/curriculum/create/page.tsx
+++ b/app/[locale]/academics/undergraduate/curriculum/create/page.tsx
@@ -12,7 +12,11 @@ const curriculumPath = getPath(curriculum);
 export default function CurriculumCreatePage() {
   return (
     <PageLayout title="전공 이수 표준 형태 추가" titleType="big">
-      <TimelineEditor submitAction={postCurriculumAction} fallbackPathname={curriculumPath} />
+      <TimelineEditor
+        submitAction={(_, formData) => postCurriculumAction(formData)}
+        fallbackPathname={curriculumPath}
+        pageName="전공 이수 표준 형태"
+      />
     </PageLayout>
   );
 }

--- a/app/[locale]/academics/undergraduate/curriculum/edit/CurriculumEditPageContent.tsx
+++ b/app/[locale]/academics/undergraduate/curriculum/edit/CurriculumEditPageContent.tsx
@@ -1,6 +1,6 @@
 import { putCurriculumAction } from '@/actions/academics';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { Curriculum } from '@/types/academics';
+import { TimelineContent } from '@/types/academics';
 import { getPath } from '@/utils/page';
 import { curriculum } from '@/utils/segmentNode';
 
@@ -8,7 +8,11 @@ import TimelineEditor from '../../../helper/timeline/TimelineEditor';
 
 const curriculumPath = getPath(curriculum);
 
-export default function CurriculumEditPageContent({ initContent }: { initContent: Curriculum }) {
+export default function CurriculumEditPageContent({
+  initContent,
+}: {
+  initContent: TimelineContent;
+}) {
   return (
     <PageLayout title="전공 이수 표준 형태 편집" titleType="big">
       <TimelineEditor

--- a/app/[locale]/academics/undergraduate/general-studies-requirements/GeneralStudiesPageContent.tsx
+++ b/app/[locale]/academics/undergraduate/general-studies-requirements/GeneralStudiesPageContent.tsx
@@ -2,11 +2,11 @@
 
 import { deleteGeneralStudiesAction } from '@/actions/academics';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { GeneralStudiesRequirement } from '@/types/academics';
+import { TimelineContent } from '@/types/academics';
 
 import TimelineViewer from '../../helper/timeline/TimelineViewer';
 
-export default function GeneralStudiesPageContent({ data }: { data: GeneralStudiesRequirement[] }) {
+export default function GeneralStudiesPageContent({ data }: { data: TimelineContent[] }) {
   return (
     <PageLayout titleType="big">
       <p className="mb-10 bg-neutral-100 px-6 py-5 text-md leading-loose">{OVERVIEW}</p>

--- a/app/[locale]/academics/undergraduate/general-studies-requirements/create/page.tsx
+++ b/app/[locale]/academics/undergraduate/general-studies-requirements/create/page.tsx
@@ -12,7 +12,11 @@ const curriculumPath = getPath(curriculum);
 export default function GeneralStudiesCreatePage() {
   return (
     <PageLayout title="필수 교양 과목 추가" titleType="big">
-      <TimelineEditor submitAction={postGeneralStudiesAction} fallbackPathname={curriculumPath} />
+      <TimelineEditor
+        submitAction={(_, formData) => postGeneralStudiesAction(formData)}
+        fallbackPathname={curriculumPath}
+        pageName="필수 교양 과목"
+      />
     </PageLayout>
   );
 }

--- a/app/[locale]/academics/undergraduate/general-studies-requirements/edit/GeneralStudiesEditPageContent.tsx
+++ b/app/[locale]/academics/undergraduate/general-studies-requirements/edit/GeneralStudiesEditPageContent.tsx
@@ -1,6 +1,6 @@
 import { putGeneralStudiesAction } from '@/actions/academics';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { GeneralStudiesRequirement } from '@/types/academics';
+import { TimelineContent } from '@/types/academics';
 import { getPath } from '@/utils/page';
 import { curriculum } from '@/utils/segmentNode';
 
@@ -11,7 +11,7 @@ const curriculumPath = getPath(curriculum);
 export default function GeneralStudiesEditPageContent({
   initContent,
 }: {
-  initContent: GeneralStudiesRequirement;
+  initContent: TimelineContent;
 }) {
   return (
     <PageLayout title="필수 교양 과목 편집" titleType="big">

--- a/types/academics.ts
+++ b/types/academics.ts
@@ -1,15 +1,12 @@
+import { Attachment } from '@/components/common/Attachments';
+
 import { Language } from './language';
 
 export type StudentType = 'undergraduate' | 'graduate';
 
 export interface Guide {
   description: string;
-  attachments: {
-    id: number;
-    name: string;
-    url: string;
-    bytes: number;
-  }[];
+  attachments: Attachment[];
 }
 
 export const GRADE = ['대학원', '1학년', '2학년', '3학년', '4학년'] as const;
@@ -35,24 +32,10 @@ export type SortOption = '학년' | '교과목 구분' | '학점';
 
 export type ViewOption = '카드형' | '목록형';
 
-export interface CourseChange {
-  year: number;
-  description: string;
-}
-
 // TODO: 삭제 (overview 없이 내용 리스트만 받도록 백엔드 api 수정될 예정)
 export interface GeneralStudiesRequirements {
   overview: string;
-  generalStudies: {
-    id: number;
-    year: number;
-    description: string;
-  }[];
-}
-
-export interface GeneralStudiesRequirement {
-  year: number;
-  description: string;
+  generalStudies: TimelineContent[];
 }
 
 export interface ScholarshipList {
@@ -69,15 +52,11 @@ export interface Scholarship {
 
 export interface DegreeRequirements {
   description: string;
-  attachments: {
-    id: number;
-    url: string;
-    name: string;
-    bytes: number;
-  }[];
+  attachments: Attachment[];
 }
 
-export interface Curriculum {
-  description: string;
+export interface TimelineContent {
   year: number;
+  description: string;
+  attachments: Attachment[];
 }


### PR DESCRIPTION
## 작업 요약

<!-- 작업한 내용을 2-3문장으로 요약합니다. -->
<!-- 예시) 보안 검수 관련 next-intl에서 사용하는 쿠키 제거 -->
academics 탭에서 사용하는 타임라인 본문들에 첨부파일을 추가할 수 있도록 수정

## 상세 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->
<!-- 예시) https://github.com/wafflestudio/csereal-web/pull/234 에서 next-intl의 lax 쿠키 사용을 막기 위해 다운그레이드했었는데, 최신 버전을 확인해보니 쿠키 자체를 막는 방법이 생겼습니다. 버전 업데이트 후 해당 플래그를 추가합니다. -->
- 타임라인 본문을 쓰는 api들 body를 기존 `application/json`에서 `formData`로 변경
- 이에 따른 `TimelineEditor` 내부 로직 수정
- 중복되는 타입 삭제 후 `TimelineContent` 타입 신설


## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->
<!-- 예시) 로컬에서 빌드 후 `document.cookie = ...` 구문이 빌드 결과물에 있는지 확인합니다. -->
전공 이수 표준 형태, 필수 교양 과목, 교과목 변경내역 페이지 편집 시 첨부파일이 정상적으로 추가/편집/삭제되는지 확인합니다. 


## 참고 문서
.
<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
<!-- 예시) https://next-intl-docs.vercel.app/docs/routing#locale-cookie 'Never use a locale prefix' 참조 -->
