### PR TITLE
♿️ 메인, 교수진, 연구실 접근성 개선

### DIFF
--- a/app/[locale]/components/NewsCarousel.tsx
+++ b/app/[locale]/components/NewsCarousel.tsx
@@ -61,11 +61,14 @@ const PageIndicator = ({
   return (
     <div className="relative flex gap-[0.63rem]">
       {[...Array(pageCnt).keys()].map((idx) => (
-        <button key={idx} onClick={() => setPage(idx)}>
+        <button key={idx} onClick={() => setPage(idx)} aria-label={`${idx + 1}번째 페이지로 이동`}>
           <CapsuleIcon current={page === idx} />
         </button>
       ))}
-      <button onClick={isScroll ? stopScroll : startScroll}>
+      <button
+        onClick={isScroll ? stopScroll : startScroll}
+        aria-label={isScroll ? '자동 스크롤 중지' : '자동 스크롤 시작'}
+      >
         {isScroll ? <PauseIcon /> : <PlayIcon />}
       </button>
     </div>

--- a/app/[locale]/components/NewsCarousel.tsx
+++ b/app/[locale]/components/NewsCarousel.tsx
@@ -61,7 +61,12 @@ const PageIndicator = ({
   return (
     <div className="relative flex gap-[0.63rem]">
       {[...Array(pageCnt).keys()].map((idx) => (
-        <button key={idx} onClick={() => setPage(idx)} aria-label={`${idx + 1}번째 페이지로 이동`}>
+        <button
+          key={idx}
+          onClick={() => setPage(idx)}
+          aria-label={`${idx + 1}번째 페이지로 이동`}
+          className="h-[24px] min-w-[24px]"
+        >
           <CapsuleIcon current={page === idx} />
         </button>
       ))}
@@ -77,7 +82,7 @@ const PageIndicator = ({
 
 const CapsuleIcon = ({ current }: { current: boolean }) => (
   <div
-    className="h-2 rounded-full transition-all duration-700"
+    className="h-2 rounded-full duration-700 ease-linear"
     style={{
       width: current ? '2.5rem' : '0.5rem',
       backgroundColor: current ? '#E65615' : '#D4D4D4',

--- a/app/[locale]/components/NewsCarousel.tsx
+++ b/app/[locale]/components/NewsCarousel.tsx
@@ -59,15 +59,19 @@ const PageIndicator = ({
   stopScroll: () => void;
 }) => {
   return (
-    <div className="relative flex gap-[0.63rem]">
+    <div className="relative flex">
       {[...Array(pageCnt).keys()].map((idx) => (
         <button
           key={idx}
           onClick={() => setPage(idx)}
           aria-label={`${idx + 1}번째 페이지로 이동`}
-          className="h-[24px] min-w-[24px]"
+          className="flex h-[1.5rem] items-center justify-center duration-700 "
+          style={{ width: page === idx ? '3.5rem' : '1.5rem' }}
         >
-          <CapsuleIcon current={page === idx} />
+          <div
+            className="mx-2 h-2 w-full rounded-full"
+            style={{ backgroundColor: page === idx ? '#E65615' : '#D4D4D4' }}
+          />
         </button>
       ))}
       <button
@@ -79,16 +83,6 @@ const PageIndicator = ({
     </div>
   );
 };
-
-const CapsuleIcon = ({ current }: { current: boolean }) => (
-  <div
-    className="h-2 rounded-full duration-700 ease-linear"
-    style={{
-      width: current ? '2.5rem' : '0.5rem',
-      backgroundColor: current ? '#E65615' : '#D4D4D4',
-    }}
-  />
-);
 
 const PauseIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} fill="none">

--- a/app/[locale]/people/components/PeopleCell.tsx
+++ b/app/[locale]/people/components/PeopleCell.tsx
@@ -26,6 +26,7 @@ export default function PeopleCell({
         href={href}
         className="relative h-48 w-36 shrink-0 cursor-pointer overflow-hidden "
         style={{ filter: 'drop-shadow(0px 0px 4px rgba(0,0,0,0.15))' }}
+        aria-label={`${title} 교수 상세 페이지로 이동`}
       >
         <ImageWithFallback
           src={imageURL}

--- a/app/[locale]/research/labs/ResearchLabListHeader.tsx
+++ b/app/[locale]/research/labs/ResearchLabListHeader.tsx
@@ -8,13 +8,13 @@ export default function ResearchLabListHeader() {
   const t = useTranslations('Content');
 
   return (
-    <h5 className="hidden h-10 items-center gap-2 whitespace-nowrap bg-neutral-100 px-2 text-sm font-medium tracking-[0.02em] sm:flex">
+    <h4 className="hidden h-10 items-center gap-2 whitespace-nowrap bg-neutral-100 px-2 text-sm font-medium tracking-[0.02em] sm:flex">
       <span className={LAB_ROW_ITEM_WIDTH.name}>{t('연구실')}</span>
       <span className={LAB_ROW_ITEM_WIDTH.professor}>{t('지도교수')}</span>
       <span className={LAB_ROW_ITEM_WIDTH.location}>{t('연구실 위치')}</span>
       <span className={LAB_ROW_ITEM_WIDTH.tel}>{t('전화')}</span>
       <span className={LAB_ROW_ITEM_WIDTH.acronym}>{t('약자')}</span>
       <span className={LAB_ROW_ITEM_WIDTH.introMaterial}>{t('소개 자료')}</span>
-    </h5>
+    </h4>
   );
 }

--- a/components/layout/footer/Footer.tsx
+++ b/components/layout/footer/Footer.tsx
@@ -124,13 +124,13 @@ function FooterBottomLeft() {
 function FooterBottomRight() {
   return (
     <div className="mt-7 flex flex-wrap gap-7 sm:mt-0 sm:flex-nowrap sm:items-center">
-      <Link href={snucomLink}>
+      <Link href={snucomLink} aria-label="서울대 컴퓨터공학 동문회 홈페이지로 이동">
         <SnucomIcon />
       </Link>
-      <Link href={snuEngLink}>
+      <Link href={snuEngLink} aria-label="서울대 공과대학 홈페이지로 이동">
         <SnuEngineeringIcon />
       </Link>
-      <Link href={snuLink}>
+      <Link href={snuLink} aria-label="서울대 홈페이지로 이동">
         <SnuLogoWithText />
       </Link>
     </div>

--- a/components/layout/header/Header.tsx
+++ b/components/layout/header/Header.tsx
@@ -29,7 +29,7 @@ export default function Header() {
 
 function HeaderLeft() {
   return (
-    <Link href="/" className="cursor-pointer">
+    <Link href="/" className="cursor-pointer" aria-label="메인으로 이동">
       {/* mobile */}
       <HeaderLogoSVG className="hidden sm:block" />
 

--- a/components/layout/header/HeaderSearchBar.tsx
+++ b/components/layout/header/HeaderSearchBar.tsx
@@ -17,6 +17,7 @@ export default function HeaderSearchBar() {
       }}
     >
       <input
+        aria-label="통합검색"
         type="text"
         id="search"
         className="autofill-bg-neutral-200 w-full bg-transparent px-2 text-xs outline-none"

--- a/components/layout/header/HeaderSearchBar.tsx
+++ b/components/layout/header/HeaderSearchBar.tsx
@@ -24,7 +24,7 @@ export default function HeaderSearchBar() {
         value={text}
         onChange={(e) => setText(e.target.value)}
       />
-      <button className="material-symbols-rounded text-[1.25rem] text-neutral-800 hover:text-neutral-500">
+      <button className="material-symbols-rounded w-8 text-[1.25rem] text-neutral-800 hover:text-neutral-500">
         search
       </button>
     </form>

--- a/components/layout/navbar/NavbarRoot.tsx
+++ b/components/layout/navbar/NavbarRoot.tsx
@@ -23,7 +23,7 @@ export default function NavbarRoot() {
       onMouseEnter={() => setNavbarState({ type: 'expanded' })}
       style={{ width: `${width}rem` }}
     >
-      <Link href="/">
+      <Link href="/" aria-label="메인으로 이동">
         <SnuLogo className="fill-white" width="56" height="58" viewBox="0 0 45 47" />
       </Link>
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import { includeIgnoreFile } from '@eslint/compat';
 import pluginJs from '@eslint/js';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
@@ -63,6 +64,15 @@ export default [
     },
     rules: {
       'unused-imports/no-unused-imports': 'error',
+    },
+  },
+  jsxA11y.flatConfigs.recommended,
+  {
+    rules: {
+      'jsx-a11y/label-has-associated-control': 'warn',
+      'jsx-a11y/click-events-have-key-events': 'warn',
+      'jsx-a11y/no-static-element-interactions': 'warn',
+      'jsx-a11y/no-noninteractive-element-interactions': 'warn',
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@types/express": "^4.17.21",
         "@types/node": "^22.10.1",
         "eslint": "^9.15.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -3857,6 +3858,16 @@
       "version": "2.0.1",
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "license": "MIT",
@@ -4068,6 +4079,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-each": {
       "version": "1.0.6",
       "funding": [
@@ -4143,6 +4161,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/b4a": {
@@ -5275,6 +5313,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -5662,6 +5707,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emojis-list": {
       "version": "3.0.0",
       "license": "MIT",
@@ -5962,6 +6014,36 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -8016,6 +8098,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/levn": {
@@ -11384,6 +11486,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string.prototype.matchall": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/express": "^4.17.21",
     "@types/node": "^22.10.1",
     "eslint": "^9.15.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",


### PR DESCRIPTION
## 작업 요약

무사 졸업을 위해 졸논 관련 작업을 했습니다.

## 상세 내용

| 페이지명       | 수정사항                                                                 |
|----------------|--------------------------------------------------------------------------|
| 공통           | - 저시력자, 고령자 등도 인식할 수 있도록 네비게이션 바, 푸터 버튼들의 명도 대비 증가 <br> - 운동 장애가 있는 경우에도 조작이 가능하게 검색 버튼을 권장 최소 크기인 24px*24px로 확대 <br> - 이미지에 링크가 달린 경우 스크린 리더가 내용을 설명할 수 있도록 라벨 추가(aria-label) <br> - 통합검색 돋보기 모양 버튼의 역할을 설명하는 라벨 추가(aria-label) |
| 메인           | - 새소식 캐러셀 페이지 버튼에서 각 버튼이 어느 페이지로 이동하는지 명시(aria-label) <br> - 운동 장애가 있는 경우에도 조작이 가능하게 캐러셀 페이지 이동 버튼을 24px*24px로 확대 |
| 교수진 목록    | - 각 교수진 이미지를 클릭 시 어느 페이지로 이동하는지 라벨 추가(aria-label) |
| 교수진 상세    | - (공통 수정 사항으로 함께 점수 개선됨)                                  |
| 연구실 목록    | - 보조 도구가 페이지의 위계를 올바르게 파악할 수 있도록 heading을 내림차순으로(h5->h4) 수정 |
| 연구실 상세    | - (공통 수정 사항으로 함께 점수 개선됨)                                  |

`eslint-plugin-jsx-a11y`를 적용했습니다. 관련 에러는 모두 warning 처리했으니 점진적으로 고쳐나가면될 것 같습니다.

## 테스트 방법

- 작업한 페이지에서 lighthouse 접근성 점수가 96점 이상이 나와야합니다.
- 메인 페이지 뉴스 캐러셀이 정상동작해야합니다.

## 참고 문서

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y?tab=readme-ov-file#readme
