### PR TITLE
🔒️ 스타일 관련 CSP 에러 수정

### DIFF
--- a/app/.internal/layout.tsx
+++ b/app/.internal/layout.tsx
@@ -1,10 +1,11 @@
 export const dynamic = 'force-dynamic';
 
 import '@/styles/globals.css';
+import 'react-toastify/dist/ReactToastify.css';
 
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
-import { Toaster } from 'react-hot-toast';
+import { ToastContainer } from 'react-toastify';
 
 import ModalContainer from '@/components/modal/ModalContainer';
 import ModalContextProvider from '@/contexts/ModalContext';
@@ -28,7 +29,7 @@ export default async function RootLayout(props: {
             <ModalContextProvider>
               {children}
               <ModalContainer />
-              <Toaster />
+              <ToastContainer />
             </ModalContextProvider>
           </SessionContextProvider>
         </NextIntlClientProvider>

--- a/app/[locale]/about/contact/page.tsx
+++ b/app/[locale]/about/contact/page.tsx
@@ -51,7 +51,7 @@ export default async function ContactPage(props: ContactPageProps) {
               }
             : undefined
         }
-        className="mt-[-1.5rem]"
+        wrapperClassName="mt-[-1.5rem]"
       />
     </PageLayout>
   );

--- a/app/[locale]/about/directions/DirectionsDetails.tsx
+++ b/app/[locale]/about/directions/DirectionsDetails.tsx
@@ -19,7 +19,7 @@ export default function DirectionsDetails({ direction }: { direction: Direction 
           />
         </LoginVisible>
       </div>
-      <HTMLViewer htmlContent={direction.description} className="ml-2.5" />
+      <HTMLViewer htmlContent={direction.description} wrapperClassName="ml-2.5" />
     </div>
   );
 }

--- a/app/[locale]/about/greetings/page.tsx
+++ b/app/[locale]/about/greetings/page.tsx
@@ -1,9 +1,8 @@
 export const dynamic = 'force-dynamic';
 
-import Image from 'next/image';
-
 import { getGreetings } from '@/apis/v1/about/greetings';
 import { EditButton } from '@/components/common/Buttons';
+import Image from '@/components/common/Image';
 import LoginVisible from '@/components/common/LoginVisible';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
@@ -31,7 +30,7 @@ export default async function GreetingsPage(props: GreetingsPageProps) {
   const { description, imageURL } = await getGreetings(params.locale);
 
   return (
-    <PageLayout titleType="big" bodyStyle={{ padding: 0 }}>
+    <PageLayout titleType="big" bodyClassName="p-0">
       <div className="px-5 pb-12 pt-7 sm:py-11 sm:pl-[6.25rem] sm:pr-[360px]">
         <LoginVisible staff>
           <div className="mb-8 text-right">
@@ -39,7 +38,7 @@ export default async function GreetingsPage(props: GreetingsPageProps) {
           </div>
         </LoginVisible>
         <div className="flex flex-col-reverse items-start gap-6 sm:flex-row sm:gap-10">
-          <HTMLViewer htmlContent={description} className="sm:w-[25rem] sm:grow" />
+          <HTMLViewer htmlContent={description} wrapperClassName="sm:w-[25rem] sm:grow" />
           {/* image 크기를 반응형으로 줄이기 위해 필요한 wrapper div */}
           {imageURL && (
             <div>

--- a/app/[locale]/about/overview/page.tsx
+++ b/app/[locale]/about/overview/page.tsx
@@ -1,11 +1,11 @@
 export const dynamic = 'force-dynamic';
 
-import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
 
 import { getOverview } from '@/apis/v1/about/overview';
 import Attachments from '@/components/common/Attachments';
 import { EditButton } from '@/components/common/Buttons';
+import Image from '@/components/common/Image';
 import LoginVisible from '@/components/common/LoginVisible';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
@@ -42,7 +42,7 @@ export default async function OverviewPage(props: OverviewPageProps) {
   const t = await getTranslations('Content');
 
   return (
-    <PageLayout titleType="big" bodyStyle={{ padding: 0 }}>
+    <PageLayout titleType="big" bodyClassName="p-0">
       <div className="bg-neutral-100 px-5 pb-12 pt-7 sm:py-11 sm:pl-[6.25rem] sm:pr-[22.5rem]">
         <LoginVisible staff>
           <div className="mb-8 text-right">
@@ -50,7 +50,7 @@ export default async function OverviewPage(props: OverviewPageProps) {
           </div>
         </LoginVisible>
         <div className="flex flex-col-reverse items-start gap-6 sm:flex-row sm:gap-10">
-          <HTMLViewer htmlContent={description} className="sm:w-[20rem] sm:grow" />
+          <HTMLViewer htmlContent={description} wrapperClassName="sm:w-[20rem] sm:grow" />
           {/* image 크기를 반응형으로 줄이기 위해 필요한 wrapper div */}
           {imageURL && (
             <div className="w-full sm:w-auto">

--- a/app/[locale]/about/student-clubs/page.tsx
+++ b/app/[locale]/about/student-clubs/page.tsx
@@ -42,7 +42,7 @@ export default async function StudentClubsPage(props: StudentClubsPageProps) {
   );
 
   return (
-    <PageLayout titleType="big" bodyStyle={{ paddingTop: 0 }}>
+    <PageLayout titleType="big" bodyClassName="pt-0">
       <LoginVisible staff>
         <div className="mt-11 text-right">
           <Link href={`${clubPath}/create`}>

--- a/app/[locale]/academics/components/courses/CourseCard.tsx
+++ b/app/[locale]/academics/components/courses/CourseCard.tsx
@@ -1,8 +1,10 @@
 import { useTranslations } from 'next-intl';
-import { CSSProperties, useEffect, useReducer, useRef } from 'react';
+import { useEffect, useReducer, useRef } from 'react';
 
 import { Course, GRADE, SortOption } from '@/apis/types/academics';
 import { useTypedLocale } from '@/utils/hooks/useTypedLocale';
+
+import styles from './style.module.css';
 
 interface CourseCardProps {
   course: Course;
@@ -56,24 +58,6 @@ export default function CourseCard({ course, selectedOption }: CourseCardProps) 
     }
   }, [isFlipped]);
 
-  const cardStyle: CSSProperties = {
-    position: 'relative',
-    paddingRight: '0.1875rem', // 3px
-    transformStyle: 'preserve-3d',
-    perspective: '1000px',
-    cursor: 'pointer',
-  };
-
-  const faceStyle: CSSProperties = {
-    top: 0,
-    left: 0,
-    height: '11rem', // 176px
-    borderRadius: '0.25rem', // 4px
-    WebkitBackfaceVisibility: 'hidden',
-    backfaceVisibility: 'hidden',
-    transition: 'transform ease-in-out 0.5s, width ease-in-out 0.5s',
-  };
-
   const frontStyle = `absolute p-[1.125rem] bg-neutral-50 hover:bg-neutral-100 active:bg-neutral-50 ${
     isFlipped ? '[transform:rotateY(-180deg)]' : '[transform:rotateY(0deg)]'
   } shadow-[2px_2px_4px_0_rgba(255,255,255,0.05)_inset,_-2px_-2px_6px_0_rgba(0,0,0,0.05)_inset]`;
@@ -83,13 +67,13 @@ export default function CourseCard({ course, selectedOption }: CourseCardProps) 
   } shadow-[2px_2px_4px_0_rgba(255,255,255,0.07)_inset,_-2px_-2px_4px_0_rgba(0,_0,_0,_0.05)_inset]`;
 
   return (
-    <div style={cardStyle} onClick={flipCard}>
-      <div className={frontStyle} style={{ ...faceStyle }} ref={frontRef}>
+    <div className={styles.card} onClick={flipCard}>
+      <div className={`${frontStyle} ${styles.face}`} ref={frontRef}>
         <CardHeader sortedProperties={sortedProperties} />
         <CardTitle name={course[language].name} code={course.code} />
         <CardContentPreview description={course[language].description} />
       </div>
-      <div className={backStyle} style={{ ...faceStyle }} ref={backRef}>
+      <div className={`${backStyle} ${styles.face}`} ref={backRef}>
         <CardTitle name={course[language].name} code={course.code} />
         <CardContent description={course[language].description} />
       </div>

--- a/app/[locale]/academics/components/courses/style.module.css
+++ b/app/[locale]/academics/components/courses/style.module.css
@@ -1,0 +1,19 @@
+.card {
+  position: relative;
+  padding-right: 0.1875rem;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+  cursor: pointer;
+}
+
+.face {
+  top: 0;
+  left: 0;
+  height: 11rem;
+  border-radius: 0.25rem;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  transition:
+    transform ease-in-out 0.5s,
+    width ease-in-out 0.5s;
+}

--- a/app/[locale]/academics/components/timeline/TimelineViewer.tsx
+++ b/app/[locale]/academics/components/timeline/TimelineViewer.tsx
@@ -165,7 +165,7 @@ function TogglableContentViewer({
 }
 
 function ContentHTMLViewer({ description }: { description: string }) {
-  return <HTMLViewer htmlContent={description} className="bg-neutral-75 p-5" />;
+  return <HTMLViewer htmlContent={description} wrapperClassName="bg-neutral-75 p-5" />;
 }
 
 const getSelectedContents = <T extends { year: number; description: string }>(

--- a/app/[locale]/academics/undergraduate/degree-requirements/page.tsx
+++ b/app/[locale]/academics/undergraduate/degree-requirements/page.tsx
@@ -38,7 +38,7 @@ export default async function UndergraduteDegreeRequirementsPage() {
         <h3 className=" mb-2 pl-3 text-lg font-bold">공통: 졸업사정 유의사항</h3>
         <StraightNode />
       </div>
-      <HTMLViewer htmlContent={data.description} className="mt-7" />
+      <HTMLViewer htmlContent={data.description} wrapperClassName="mt-7" />
     </PageLayout>
   );
 }

--- a/app/[locale]/admissions/international/exchange/page.tsx
+++ b/app/[locale]/admissions/international/exchange/page.tsx
@@ -26,8 +26,8 @@ export default async function InternationalExchangePage() {
   const { description } = await getInternationalExchangeVisiting();
 
   return (
-    <PageLayout titleType="big" bodyStyle={{ paddingBottom: 0 }}>
-      <HTMLViewer htmlContent={description} className="pb-16 sm:pb-[220px]" />
+    <PageLayout titleType="big" bodyClassName="pb-0">
+      <HTMLViewer htmlContent={description} wrapperClassName="pb-16 sm:pb-[220px]" />
     </PageLayout>
   );
 }

--- a/app/[locale]/admissions/international/scholarships/page.tsx
+++ b/app/[locale]/admissions/international/scholarships/page.tsx
@@ -26,8 +26,8 @@ export default async function InternationalScholarshipPage() {
   const { description } = await getInternationalScholarships();
 
   return (
-    <PageLayout titleType="big" bodyStyle={{ paddingBottom: 0 }}>
-      <HTMLViewer htmlContent={description} className="pb-16 sm:pb-[220px]" />
+    <PageLayout titleType="big" bodyClassName="pb-0">
+      <HTMLViewer htmlContent={description} wrapperClassName="pb-16 sm:pb-[220px]" />
     </PageLayout>
   );
 }

--- a/app/[locale]/community/news/[id]/NewsViewer.tsx
+++ b/app/[locale]/community/news/[id]/NewsViewer.tsx
@@ -7,7 +7,7 @@ import Attachments from '@/components/common/Attachments';
 import { StraightNode } from '@/components/common/Nodes';
 import Tags from '@/components/common/Tags';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
-import { PAGE_PADDING_BOTTOM_PX } from '@/components/layout/pageLayout/PageLayout';
+import { PAGE_PADDING_BOTTOM_TAILWIND } from '@/components/layout/pageLayout/PageLayout';
 import { news } from '@/constants/segmentNode';
 import { formatNewsPostDateStr } from '@/utils/date';
 import { getPath } from '@/utils/page';
@@ -23,8 +23,7 @@ export default async function NewsViewer({ news }: NewsPostPageProps) {
     <>
       <Header title={news.title} date={news.date} />
       <div
-        className="bg-neutral-50 px-5 pt-9 sm:pl-[100px] sm:pr-[340px]"
-        style={{ paddingBottom: PAGE_PADDING_BOTTOM_PX }}
+        className={`bg-neutral-50 px-5 pt-9 sm:pl-[100px] sm:pr-[340px] ${PAGE_PADDING_BOTTOM_TAILWIND}`}
       >
         <Attachments files={news.attachments} />
         <HTMLViewer
@@ -34,7 +33,7 @@ export default async function NewsViewer({ news }: NewsPostPageProps) {
               ? { type: 'image', url: news.imageURL, widthPX: 320, heightPX: 240 }
               : undefined
           }
-          className="mb-10"
+          wrapperClassName="mb-10"
         />
         <StraightNode />
         <Tags tags={news.tags} margin="mt-3 ml-6" searchPath={newsPath} />

--- a/app/[locale]/community/news/[id]/page.tsx
+++ b/app/[locale]/community/news/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function NewsPostPage(props: NewsPostPageProps) {
     const news = await getNewsDetail(id, searchParams);
 
     return (
-      <PageLayout titleType="big" bodyStyle={{ padding: 0 }}>
+      <PageLayout titleType="big" bodyClassName="p-0">
         <Suspense fallback={<PostFallback />}>
           <NewsViewer news={news} />
         </Suspense>

--- a/app/[locale]/community/notice/[id]/NoticeViewer.tsx
+++ b/app/[locale]/community/notice/[id]/NoticeViewer.tsx
@@ -6,7 +6,7 @@ import Attachments from '@/components/common/Attachments';
 import { StraightNode } from '@/components/common/Nodes';
 import Tags from '@/components/common/Tags';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
-import { PAGE_PADDING_BOTTOM_PX } from '@/components/layout/pageLayout/PageLayout';
+import { PAGE_PADDING_BOTTOM_TAILWIND } from '@/components/layout/pageLayout/PageLayout';
 import { notice } from '@/constants/segmentNode';
 import { formatPostDateStr } from '@/utils/date';
 import { getPath } from '@/utils/page';
@@ -22,13 +22,10 @@ export default async function NoticeViewer({ notice }: NoticePostPageProps) {
     <>
       <Header {...notice} />
       <div
-        className="bg-neutral-50 px-5 pt-9 sm:pl-[100px] sm:pr-[340px]"
-        style={{
-          paddingBottom: PAGE_PADDING_BOTTOM_PX,
-        }}
+        className={`bg-neutral-50 px-5 pt-9 sm:pl-[100px] sm:pr-[340px] ${PAGE_PADDING_BOTTOM_TAILWIND}`}
       >
         <Attachments files={notice.attachments} />
-        <HTMLViewer htmlContent={notice.description} className="mb-10" />
+        <HTMLViewer htmlContent={notice.description} wrapperClassName="mb-10" />
         <StraightNode />
         <Tags tags={notice.tags} margin="mt-3 ml-6" searchPath={noticePath} />
         <PostFooter post={notice} postType="notice" id={notice.id.toString()} margin="mt-12" />

--- a/app/[locale]/community/notice/[id]/page.tsx
+++ b/app/[locale]/community/notice/[id]/page.tsx
@@ -49,7 +49,7 @@ export default async function NoticePostPage(props: NoticePostPageProps) {
   try {
     const notice = await getNoticePostDetail(id, searchParams);
     return (
-      <PageLayout titleType="big" bodyStyle={{ padding: 0 }}>
+      <PageLayout titleType="big" bodyClassName="p-0">
         <Suspense fallback={<PostFallback />}>
           <NoticeViewer notice={notice} />
         </Suspense>

--- a/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
+++ b/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
@@ -7,7 +7,7 @@ import Attachments from '@/components/common/Attachments';
 import ImageWithFallback from '@/components/common/ImageWithFallback';
 import { StraightNode } from '@/components/common/Nodes';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
-import { PAGE_PADDING_BOTTOM_PX } from '@/components/layout/pageLayout/PageLayout';
+import { PAGE_PADDING_BOTTOM_TAILWIND } from '@/components/layout/pageLayout/PageLayout';
 import { Link } from '@/i18n/routing';
 
 interface SeminarPostPageProps {
@@ -23,8 +23,7 @@ export default async function SeminarViewer({ seminar }: SeminarPostPageProps) {
         {seminar.title}
       </h2>
       <div
-        className="bg-neutral-50 px-5 pt-9 sm:pl-[100px] sm:pr-[340px]"
-        style={{ paddingBottom: PAGE_PADDING_BOTTOM_PX }}
+        className={`bg-neutral-50 px-5 pt-9 sm:pl-[100px] sm:pr-[340px] ${PAGE_PADDING_BOTTOM_TAILWIND}`}
       >
         {seminar.attachments.length !== 0 && <Attachments files={seminar.attachments} />}
         <div className="mb-9 flex flex-col-reverse justify-between gap-5 text-md sm:flex-row">

--- a/app/[locale]/community/seminar/[id]/page.tsx
+++ b/app/[locale]/community/seminar/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function SeminarPostPage(props: SeminarPostPageProps) {
     const seminar = await getSeminarPost(id, searchParams);
 
     return (
-      <PageLayout titleType="big" bodyStyle={{ padding: 0 }}>
+      <PageLayout titleType="big" bodyClassName="p-0">
         <Suspense fallback={<PostFallback />}>
           <SeminarViewer seminar={seminar} />
         </Suspense>

--- a/app/[locale]/components/GraphicSection.tsx
+++ b/app/[locale]/components/GraphicSection.tsx
@@ -1,7 +1,7 @@
 import localFont from 'next/font/local';
-import Image from 'next/image';
 import { ReactNode } from 'react';
 
+import Image from '@/components/common/Image';
 import DownArrow from '@/public/image/main/down_arrow.svg';
 
 const gowunBatang = localFont({ src: './GowunBatang-Regular.woff2' });

--- a/app/[locale]/components/NewsCard.tsx
+++ b/app/[locale]/components/NewsCard.tsx
@@ -1,17 +1,15 @@
-import Image from 'next/image';
-
 import { MainNews } from '@/apis/types/main';
+import Image from '@/components/common/Image';
 import { Link } from '@/i18n/routing';
 import { formatMainNewsDateStr } from '@/utils/date';
 
-import { CARD_WIDTH_REM } from './constants';
+import { CARD_WIDTH_TAILWIND } from './constants';
 
 export default function NewsCard({ news }: { news: MainNews }) {
   return (
     <Link
       href={`/community/news/${news.id}`}
-      style={{ width: `${CARD_WIDTH_REM}rem` }}
-      className="flex h-[19rem] shrink-0 flex-col bg-neutral-50 shadow-[0_0_31.9px_0_rgba(0,0,0,0.07)]"
+      className={`flex h-[19rem] shrink-0 flex-col bg-neutral-50 shadow-[0_0_31.9px_0_rgba(0,0,0,0.07)] ${CARD_WIDTH_TAILWIND}`}
     >
       <div className="relative h-[6.25rem] w-full">
         <Image src={encodeURI(news.imageURL)} fill alt="" className="object-cover" sizes="220w" />

--- a/app/[locale]/components/NewsCarousel.tsx
+++ b/app/[locale]/components/NewsCarousel.tsx
@@ -106,16 +106,7 @@ const PageIndicatorDot = ({
 
 const PauseIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} fill="none">
-    <mask
-      id="a"
-      width={24}
-      height={24}
-      x={0}
-      y={0}
-      maskUnits="userSpaceOnUse"
-      // eslint-disable-next-line react/forbid-dom-props
-      style={{ maskType: 'alpha' }}
-    >
+    <mask id="a" width={24} height={24} x={0} y={0} maskUnits="userSpaceOnUse">
       <path fill="#D9D9D9" d="M0 0h24v24H0z" />
     </mask>
     <g mask="url(#a)">
@@ -126,16 +117,7 @@ const PauseIcon = () => (
 
 const PlayIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} fill="none">
-    <mask
-      id="a"
-      width={24}
-      height={24}
-      x={0}
-      y={0}
-      maskUnits="userSpaceOnUse"
-      // eslint-disable-next-line react/forbid-dom-props
-      style={{ maskType: 'alpha' }}
-    >
+    <mask id="a" width={24} height={24} x={0} y={0} maskUnits="userSpaceOnUse">
       <path fill="#D9D9D9" d="M0 0h24v24H0z" />
     </mask>
     <g mask="url(#a)">

--- a/app/[locale]/components/NewsCarousel.tsx
+++ b/app/[locale]/components/NewsCarousel.tsx
@@ -113,6 +113,7 @@ const PauseIcon = () => (
       x={0}
       y={0}
       maskUnits="userSpaceOnUse"
+      // eslint-disable-next-line react/forbid-dom-props
       style={{ maskType: 'alpha' }}
     >
       <path fill="#D9D9D9" d="M0 0h24v24H0z" />
@@ -132,6 +133,7 @@ const PlayIcon = () => (
       x={0}
       y={0}
       maskUnits="userSpaceOnUse"
+      // eslint-disable-next-line react/forbid-dom-props
       style={{ maskType: 'alpha' }}
     >
       <path fill="#D9D9D9" d="M0 0h24v24H0z" />

--- a/app/[locale]/components/NewsCarousel.tsx
+++ b/app/[locale]/components/NewsCarousel.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from 'react';
+import { ButtonHTMLAttributes, useEffect } from 'react';
 
 import { MainNews } from '@/apis/types/main';
+import useStyle from '@/utils/hooks/useStyle';
 
 import { animateScrollLeft } from './animateScrollTo';
-import { CARD_GAP_REM } from './constants';
+import { CARD_GAP_REM, CARD_GAP_TAILWIND } from './constants';
 import NewsCard from './NewsCard';
 import useCarousel from './useCarousel';
 import { useCarouselLayout } from './useCarouselLayout';
@@ -12,19 +13,21 @@ export default function NewsCarousel({ news }: { news: MainNews[] }) {
   const { offsetREM, pageCnt, setPage, page, isScroll, startScroll, stopScroll } =
     useCarousel(news);
   const { widthREM } = useCarouselLayout();
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { ref: containerRef } = useStyle<HTMLDivElement>(
+    (style) => (style.width = `${widthREM - CARD_GAP_REM}rem`),
+    [widthREM],
+  );
 
   useEffect(() => {
     if (containerRef.current === null) return;
 
     return animateScrollLeft(containerRef.current, offsetREM * 16);
-  }, [offsetREM]);
+  }, [containerRef, offsetREM]);
 
   return (
     <div className="flex flex-col items-center">
       <div
-        className="no-scrollbar mx-auto flex overflow-x-hidden pb-10"
-        style={{ width: `${widthREM - CARD_GAP_REM}rem`, gap: `${CARD_GAP_REM}rem` }}
+        className={`no-scrollbar mx-auto flex overflow-x-hidden pb-10 ${CARD_GAP_TAILWIND}`}
         ref={containerRef}
       >
         {news.map((news) => (
@@ -61,18 +64,12 @@ const PageIndicator = ({
   return (
     <div className="relative flex">
       {[...Array(pageCnt).keys()].map((idx) => (
-        <button
+        <PageIndicatorDot
           key={idx}
-          onClick={() => setPage(idx)}
           aria-label={`${idx + 1}번째 페이지로 이동`}
-          className="flex h-[1.5rem] items-center justify-center duration-700 "
-          style={{ width: page === idx ? '3.5rem' : '1.5rem' }}
-        >
-          <div
-            className="mx-2 h-2 w-full rounded-full"
-            style={{ backgroundColor: page === idx ? '#E65615' : '#D4D4D4' }}
-          />
-        </button>
+          isHighlight={page === idx}
+          onClick={() => setPage(idx)}
+        />
       ))}
       <button
         onClick={isScroll ? stopScroll : startScroll}
@@ -81,6 +78,29 @@ const PageIndicator = ({
         {isScroll ? <PauseIcon /> : <PlayIcon />}
       </button>
     </div>
+  );
+};
+
+const PageIndicatorDot = ({
+  isHighlight,
+  ...props
+}: {
+  isHighlight: boolean;
+} & ButtonHTMLAttributes<HTMLButtonElement>) => {
+  return (
+    <button
+      className="flex h-[1.5rem] items-center justify-center duration-700 "
+      {...props}
+      {...useStyle((style) => (style.width = isHighlight ? '3.5rem' : '1.5rem'), [isHighlight])}
+    >
+      <div
+        className="mx-2 h-2 w-full rounded-full"
+        {...useStyle(
+          (style) => (style.backgroundColor = isHighlight ? '#E65615' : '#D4D4D4'),
+          [isHighlight],
+        )}
+      />
+    </button>
   );
 };
 
@@ -93,9 +113,7 @@ const PauseIcon = () => (
       x={0}
       y={0}
       maskUnits="userSpaceOnUse"
-      style={{
-        maskType: 'alpha',
-      }}
+      style={{ maskType: 'alpha' }}
     >
       <path fill="#D9D9D9" d="M0 0h24v24H0z" />
     </mask>
@@ -114,9 +132,7 @@ const PlayIcon = () => (
       x={0}
       y={0}
       maskUnits="userSpaceOnUse"
-      style={{
-        maskType: 'alpha',
-      }}
+      style={{ maskType: 'alpha' }}
     >
       <path fill="#D9D9D9" d="M0 0h24v24H0z" />
     </mask>

--- a/app/[locale]/components/NoticeSection.tsx
+++ b/app/[locale]/components/NoticeSection.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { ReactNode, useState } from 'react';
 
 import { AllMainNotice } from '@/apis/types/main';
+import Image from '@/components/common/Image';
 import { notice } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
 import Plus from '@/public/image/main/plus.svg';

--- a/app/[locale]/components/constants.ts
+++ b/app/[locale]/components/constants.ts
@@ -1,3 +1,5 @@
 export const CARD_WIDTH_REM = 13.8;
+export const CARD_WIDTH_TAILWIND = 'w-[13.8rem]';
 export const CARD_GAP_REM = 2;
+export const CARD_GAP_TAILWIND = 'gap-[2rem]';
 export const AUTO_SCROLL_MS = 5000;

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,13 +1,14 @@
 export const dynamic = 'force-dynamic';
 
 import '@/styles/globals.css';
+import 'react-toastify/dist/ReactToastify.css';
 
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
-import { Toaster } from 'react-hot-toast';
+import { ToastContainer } from 'react-toastify';
 
 import Footer from '@/components/layout/footer/Footer';
 import MobileNav from '@/components/layout/navbar/MobileNav';
@@ -68,7 +69,7 @@ export default async function RootLayout(props: {
           </MarginedMain>
 
           <ModalContainer />
-          <Toaster />
+          <ToastContainer />
         </ContextProviders>
       </body>
     </html>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
 
 import { MainImportant } from '@/apis/types/main';
@@ -6,6 +5,7 @@ import { getMain } from '@/apis/v1';
 import GraphicSection from '@/app/[locale]/components/GraphicSection';
 import NewsSection from '@/app/[locale]/components/NewsSection';
 import NoticeSection from '@/app/[locale]/components/NoticeSection';
+import Image from '@/components/common/Image';
 import Header from '@/components/layout/header/Header';
 import {
   degree,

--- a/app/[locale]/research/centers/ResearchCenterDetails.tsx
+++ b/app/[locale]/research/centers/ResearchCenterDetails.tsx
@@ -55,7 +55,7 @@ export default function ResearchCenterDetails({ center, ids }: ResearchCenterDet
               }
             : undefined
         }
-        className="px-2.5"
+        wrapperClassName="px-2.5"
       />
     </>
   );

--- a/app/[locale]/research/centers/page.tsx
+++ b/app/[locale]/research/centers/page.tsx
@@ -46,7 +46,7 @@ export default async function ResearchCentersPage(props: {
   const centerWithLanguage = await getResearchCenter(selectedCenter.id);
 
   return (
-    <PageLayout titleType="big" bodyStyle={{ paddingTop: 0 }}>
+    <PageLayout titleType="big" bodyClassName="pt-0">
       <LoginVisible staff>
         <div className="mt-11 text-right">
           <Link href={`${researchCentersPath}/create`}>

--- a/app/[locale]/research/groups/ResearchGroupDetails.tsx
+++ b/app/[locale]/research/groups/ResearchGroupDetails.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 
 import { deleteResearchGroupAction } from '@/actions/research';
 import { ResearchGroup } from '@/apis/types/research';
 import { DeleteButton, EditButton } from '@/components/common/Buttons';
+import Image from '@/components/common/Image';
 import LoginVisible from '@/components/common/LoginVisible';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
 import { researchGroups } from '@/constants/segmentNode';
@@ -51,7 +51,7 @@ export default function ResearchGroupDetails({ group, ids }: ResearchGroupDetail
       </div>
       <HTMLViewer
         htmlContent={group.description}
-        className="max-w-[780px] bg-white p-[18px] sm:mx-0 sm:p-[40px]"
+        wrapperClassName="max-w-[780px] bg-white p-[18px] sm:mx-0 sm:p-[40px]"
       />
       {group.mainImageUrl !== null && (
         // TODO: 반응형

--- a/app/[locale]/research/groups/page.tsx
+++ b/app/[locale]/research/groups/page.tsx
@@ -42,7 +42,7 @@ export default async function ResearchGroupsPage(props: {
   const groupWithLanguage = await getResearchGroup(selectedGroup.id);
 
   return (
-    <PageLayout titleType="big" bodyStyle={{ padding: 0 }}>
+    <PageLayout titleType="big" bodyClassName="p-0">
       {/* TODO: 외부 div 스타일링 SelectionList에서 표현 */}
       <div className="px-7 sm:pl-[100px] sm:pr-[320px]">
         <LoginVisible staff>

--- a/app/[locale]/research/labs/[id]/ResearchLabDetailContent.tsx
+++ b/app/[locale]/research/labs/[id]/ResearchLabDetailContent.tsx
@@ -58,7 +58,7 @@ export default function ResearchLabDetailContent({
         topRightContent={
           isMobile ? undefined : { type: 'component', content: <ResearchLabInfo lab={lab} /> }
         }
-        className="mt-6"
+        wrapperClassName="mt-6"
       />
     </div>
   );

--- a/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/CalendarColumn.tsx
+++ b/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/CalendarColumn.tsx
@@ -4,6 +4,7 @@ import ReservationModalButton from '../modals/ReservationDetailModal';
 import styles from './cellstyle.module.css';
 
 const UNIT_HEIGHT_IN_REM = 1.5;
+const UNIT_HEIGHT_TAILWIND = 'h-[1.5rem]';
 const THIRTY_MIN_IN_MILLISEC = 1000 * 60 * 30;
 
 export default function CalendarColumn({
@@ -50,8 +51,7 @@ const ColumnBackground = ({ selected }: { selected: boolean }) => {
     .map((_, i) => (
       <div
         key={i}
-        className={`box-border ${styles.cell} ${selected && 'bg-neutral-100'}`}
-        style={{ height: UNIT_HEIGHT_IN_REM + 'rem' }}
+        className={`box-border ${styles.cell} ${selected && 'bg-neutral-100'} ${UNIT_HEIGHT_TAILWIND}`}
       />
     ));
 };
@@ -69,10 +69,7 @@ const CalendarCell = async ({ reservation }: { reservation: ReservationPreview }
       top={topOffset + 'rem'}
     >
       {unitCnt !== 1 && <CalendarCellTitle startTime={startTime} endTime={endTime} />}
-      <p
-        className="item-center flex text-xs font-medium"
-        style={{ height: UNIT_HEIGHT_IN_REM + 'rem' }}
-      >
+      <p className={`item-center flex text-xs font-medium ${UNIT_HEIGHT_TAILWIND}`}>
         {reservation.title}
       </p>
     </ReservationModalButton>
@@ -86,8 +83,7 @@ const CalendarCellTitle = ({ startTime, endTime }: { startTime: Date; endTime: D
 
   return (
     <p
-      className="mt-[2px] flex items-center text-xs font-bold text-neutral-800"
-      style={{ height: UNIT_HEIGHT_IN_REM + 'rem' }}
+      className={`mt-[2px] flex items-center text-xs font-bold text-neutral-800 ${UNIT_HEIGHT_TAILWIND}`}
     >
       {timeText}
     </p>

--- a/app/[locale]/reservations/[roomType]/[roomName]/helper/modals/ReservationDetailModal.tsx
+++ b/app/[locale]/reservations/[roomType]/[roomName]/helper/modals/ReservationDetailModal.tsx
@@ -12,6 +12,7 @@ import LoginVisible from '@/components/common/LoginVisible';
 import AlertModal from '@/components/modal/AlertModal';
 import ModalFrame from '@/components/modal/ModalFrame';
 import useModal from '@/utils/hooks/useModal';
+import useStyle from '@/utils/hooks/useStyle';
 import { refreshPage } from '@/utils/refreshPage';
 import { handleServerAction } from '@/utils/serverActionError';
 import { errorToast, successToast } from '@/utils/toast';
@@ -41,8 +42,14 @@ export default function ReservationModalButton({
   return (
     <button
       className={`absolute flex w-full flex-col items-center bg-[#ff6914cc]`}
-      style={{ height, top }}
       onClick={handleClick}
+      {...useStyle(
+        (style) => {
+          style.height = height;
+          style.top = top;
+        },
+        [height, top],
+      )}
     >
       {children}
     </button>

--- a/app/[locale]/reservations/introduction/page.tsx
+++ b/app/[locale]/reservations/introduction/page.tsx
@@ -30,7 +30,7 @@ export default async function ReservationIntroductionPage(props: {
   const itemName = isSearchParamValid(temp) ? temp : names[0].ko;
 
   return (
-    <PageLayout titleType="big" bodyStyle={{ paddingTop: 0, paddingBottom: 300 }}>
+    <PageLayout titleType="big" bodyClassName="pt-0 pb-[300px]">
       <SelectionList
         names={names}
         selectedItemNameKo={itemName}

--- a/app/[locale]/search/helper/NavbarButton.tsx
+++ b/app/[locale]/search/helper/NavbarButton.tsx
@@ -1,17 +1,14 @@
 'use client';
 
-import { CSSProperties } from 'react';
-
 import { TreeNode } from './SearchSubNavbar';
 
-export default function NavbarButton({ node, style }: { node: TreeNode; style: CSSProperties }) {
+export default function NavbarButton({ node, className }: { node: TreeNode; className: string }) {
   return (
     <button
       onClick={() => scrollToSection(`nav_${node.name}`)}
       className={`block text-left text-sm ${
         node.bold ? 'font-bold text-main-orange' : 'text-neutral-700'
-      } ${node.size === undefined || node.size === 0 ? 'pointer-events-none' : ''}`}
-      style={style}
+      } ${node.size === undefined || node.size === 0 ? 'pointer-events-none' : ''} ${className}`}
     >
       {node.name}
       {node.size !== undefined && `(${node.size})`}

--- a/app/[locale]/search/helper/SearchSubNavbar.tsx
+++ b/app/[locale]/search/helper/SearchSubNavbar.tsx
@@ -9,8 +9,6 @@ export type TreeNode = {
   bold?: boolean;
 };
 
-export const INDENTATION = 16;
-
 // TODO: 번역
 export default function SearchSubNavbar({ node }: { node: TreeNode[] }) {
   return (
@@ -36,9 +34,9 @@ export default function SearchSubNavbar({ node }: { node: TreeNode[] }) {
 const SubTab = ({ node }: { node: TreeNode }) => {
   return (
     <>
-      <NavbarButton node={node} style={{ marginLeft: INDENTATION }} />
+      <NavbarButton node={node} className="ml-[16px]" />
       {node.children?.map((childNode, idx) => (
-        <NavbarButton node={childNode} key={idx} style={{ marginLeft: INDENTATION * 2 }} />
+        <NavbarButton node={childNode} key={idx} className="ml-[32px]" />
       ))}
     </>
   );

--- a/components/common/CornerFoldedRectangle/index.tsx
+++ b/components/common/CornerFoldedRectangle/index.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties, ReactNode } from 'react';
 
 import { ColorTheme } from '@/constants/color';
+import useStyle from '@/utils/hooks/useStyle';
 
 import styles from './style.module.css';
 
@@ -41,29 +42,45 @@ export default function CornerFoldedRectangle({
     filter: triangleDropShadow,
   };
 
+  const { ref: rectangleRef } = useStyle<HTMLDivElement>(
+    (style) => {
+      Object.assign(style, rectangleStyle);
+    },
+    [rectangleStyle],
+  );
+
+  const { ref: triangleRef } = useStyle<HTMLDivElement>(
+    (style) => {
+      Object.assign(style, triangleStyle);
+    },
+    [triangleStyle],
+  );
+
+  const { ref } = useStyle<HTMLDivElement>(
+    (style) => {
+      style.borderWidth = `${triangleLength}rem 0 0 ${triangleLength}rem`;
+      style.borderColor = `#ffffff #ffffff ${colorTheme.triangleColor} ${colorTheme.triangleColor}`;
+      style.borderBottomLeftRadius = `${radius}rem`;
+    },
+    [triangleLength, colorTheme.triangleColor, radius],
+  );
+
   if (animationType) {
     return (
       <div
         className={`relative ${width} ${margin} ${styles.animated} ${styles[animationType]}`}
-        style={rectangleStyle}
+        ref={rectangleRef}
       >
         {children}
       </div>
     );
   } else {
     return (
-      <div className={`relative ${width} ${margin}`} style={rectangleStyle}>
+      <div className={`relative ${width} ${margin}`} ref={rectangleRef}>
+        <div className={`absolute right-[-1px] top-[-1px] h-0 w-0 border-solid`} ref={ref} />
         <div
           className={`absolute right-[-1px] top-[-1px] h-0 w-0 border-solid`}
-          style={{
-            borderWidth: `${triangleLength}rem 0 0 ${triangleLength}rem`,
-            borderColor: `#ffffff #ffffff ${colorTheme.triangleColor} ${colorTheme.triangleColor}`,
-            borderBottomLeftRadius: `${radius}rem`,
-          }}
-        />
-        <div
-          className={`absolute right-[-1px] top-[-1px] h-0 w-0 border-solid`}
-          style={triangleStyle}
+          ref={triangleRef}
         />
         {children}
       </div>

--- a/components/common/Image.tsx
+++ b/components/common/Image.tsx
@@ -1,11 +1,22 @@
+'use client';
+
 import NextImage, { getImageProps } from 'next/image';
 import { ComponentProps } from 'react';
+
+import useStyle from '@/utils/hooks/useStyle';
 
 export default function Image(props: ComponentProps<typeof NextImage>) {
   const { props: nextProps } = getImageProps({ ...props });
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { style: _omit, alt, ...delegated } = nextProps;
+  const { style, alt, ...delegated } = nextProps;
 
-  return <img {...delegated} alt={alt} />;
+  return (
+    <img
+      {...delegated}
+      alt={alt}
+      {...useStyle((_style) => {
+        Object.assign(_style, style);
+      }, [])}
+    />
+  );
 }

--- a/components/common/Image.tsx
+++ b/components/common/Image.tsx
@@ -1,0 +1,11 @@
+import NextImage, { getImageProps } from 'next/image';
+import { ComponentProps } from 'react';
+
+export default function Image(props: ComponentProps<typeof NextImage>) {
+  const { props: nextProps } = getImageProps({ ...props });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { style: _omit, alt, ...delegated } = nextProps;
+
+  return <img {...delegated} alt={alt} />;
+}

--- a/components/common/Image.tsx
+++ b/components/common/Image.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+// eslint-disable-next-line no-restricted-imports
 import NextImage, { getImageProps } from 'next/image';
 import { ComponentProps } from 'react';
 

--- a/components/common/ImageWithFallback.tsx
+++ b/components/common/ImageWithFallback.tsx
@@ -1,13 +1,21 @@
 'use client';
 
-import Image from 'next/image';
 import { CSSProperties, useState } from 'react';
 
+import Image from '@/components/common/Image';
 import SnuLogo from '@/public/image/SNU_Logo.svg';
+import useStyle from '@/utils/hooks/useStyle';
 
 export default function ImageWithFallback(props: ImageWithFallbackProps) {
   const { ...rest } = props;
   const [error, setError] = useState(false);
+  const { ref } = useStyle<HTMLDivElement>(
+    (style) => {
+      style.width = `${props.width}px`;
+      style.height = `${props.height}px`;
+    },
+    [props.width, props.height],
+  );
 
   if (error || !props.src) {
     return (
@@ -15,7 +23,7 @@ export default function ImageWithFallback(props: ImageWithFallbackProps) {
         className={`flex items-center justify-center bg-neutral-100 ${
           props.fill && 'h-full w-full'
         }`}
-        style={{ width: props.width, height: props.height }}
+        ref={ref}
       >
         <SnuLogo className="fill-neutral-200" width="60" height="60" />
       </div>

--- a/components/common/search/TagFilter.tsx
+++ b/components/common/search/TagFilter.tsx
@@ -1,5 +1,7 @@
 import { useLocale, useTranslations } from 'next-intl';
 
+import useStyle from '@/utils/hooks/useStyle';
+
 import Checkbox from '../../form/legacy/Checkbox';
 
 interface TagFilterProps {
@@ -26,14 +28,16 @@ export default function TagFilter({ tags, selectedTags, disabled, searchTags }: 
     <div>
       <h5 className="mb-3 mr-6 whitespace-nowrap text-md font-bold tracking-wide">{t('태그')}</h5>
       <div
-        className={`gap-x-7 gap-y-2.5 pl-2.5`}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: `repeat(auto-fill, minmax(${calculateWidth(
-            tags.map((tag) => t(tag)),
-            locale,
-          )}px, auto))`,
-        }}
+        className={`grid gap-x-7 gap-y-2.5 pl-2.5`}
+        {...useStyle(
+          (style) => {
+            style.gridTemplateColumns = `repeat(auto-fill, minmax(${calculateWidth(
+              tags.map((tag) => t(tag)),
+              locale,
+            )}px, auto))`;
+          },
+          [tags],
+        )}
       >
         {tags.map((tag) => (
           <Checkbox

--- a/components/form/Image.tsx
+++ b/components/form/Image.tsx
@@ -1,6 +1,7 @@
-import Image from 'next/image';
 import { ChangeEventHandler, MouseEventHandler, useEffect, useState } from 'react';
 import { RegisterOptions, useFormContext, useWatch } from 'react-hook-form';
+
+import Image from '@/components/common/Image';
 
 import { LocalImage, UploadedImage } from '../../types/form';
 
@@ -77,15 +78,7 @@ const SelectedImageViewer = ({
     rounded-sm border border-neutral-200 bg-neutral-50 
     pb-2 pl-2 pr-4 pt-2`}
     >
-      <Image
-        src={imageURL}
-        alt="선택된 이미지"
-        width={IMAGE_WIDTH}
-        height={imageHeight}
-        // 경고 제거용 style prop
-        // 참고: https://github.com/vercel/next.js/issues/40762
-        style={{ width: IMAGE_WIDTH, height: imageHeight }}
-      />
+      <Image src={imageURL} alt="선택된 이미지" width={IMAGE_WIDTH} height={imageHeight} />
       <div className="flex flex-col items-start justify-between">
         <p className="text-xs">{`${file.file.name}(${fileSizeRounded}KB)`}</p>
         <button className="text-xs underline" onClick={handleDeleteBlob}>

--- a/components/form/html/HTMLViewer.tsx
+++ b/components/form/html/HTMLViewer.tsx
@@ -5,10 +5,11 @@
 import './suneditor-contents.css';
 
 import { Autolinker } from 'autolinker';
-import { CSSProperties, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import ImageWithFallback from '@/components/common/ImageWithFallback';
 import useResponsive from '@/utils/hooks/useResponsive';
+import useStyle from '@/utils/hooks/useStyle';
 
 interface TopRightComponent {
   type: 'component';
@@ -19,28 +20,27 @@ interface HTMLViewerProps {
   htmlContent: string;
   // 우측 상단 표시될 요소
   topRightContent?: TopRightImage | TopRightComponent;
-  className?: string;
-  style?: CSSProperties;
+  wrapperClassName?: string;
+  contentClassName?: string;
 }
 
 export default function HTMLViewer({
   htmlContent,
   topRightContent,
-  className = '',
-  style,
+  wrapperClassName,
+  contentClassName,
 }: HTMLViewerProps) {
   // TODO: 서버에서 link 처리?
   // 400.XXX같은 값들이 링크 처리되는걸 막기 위해 tldMatches false처리
   const linkedHTML = Autolinker.link(htmlContent, { urls: { tldMatches: false } });
 
   return (
-    <div className={`flow-root ${className}`}>
+    <div className={`flow-root ${wrapperClassName}`}>
       {topRightContent?.type === 'image' && <TopRightImageContent {...topRightContent} />}
       {topRightContent?.type === 'component' && <TopRightComponent {...topRightContent} />}
       <div
-        className="sun-editor-editable"
+        className={`sun-editor-editable ${contentClassName}`}
         dangerouslySetInnerHTML={{ __html: linkedHTML }}
-        style={style}
       />
     </div>
   );
@@ -66,10 +66,13 @@ function TopRightImageContent(props: TopRightImage) {
   return (
     <div
       className="relative mb-7 w-full sm:float-right sm:ml-7 sm:w-auto"
-      style={{
-        width: isMobile && props.mobileFullWidth ? undefined : width,
-        marginTop,
-      }}
+      {...useStyle(
+        (style) => {
+          style.width = isMobile && props.mobileFullWidth ? '' : `${width}px`;
+          style.marginTop = `${marginTop}px`;
+        },
+        [isMobile, props.mobileFullWidth, marginTop],
+      )}
     >
       <ImageWithFallback
         src={url}

--- a/components/layout/navbar/MobileNav.tsx
+++ b/components/layout/navbar/MobileNav.tsx
@@ -13,18 +13,13 @@ import { isAncestorNode } from '@/utils/page';
 
 import MobileNavDetail from './MobileNavDetail';
 
-const HEADER_HEIGHT_PX = 68;
-
 // TODO: 모바일에서 MajorCategoryPageLayout 처리
 export default function MobileNav() {
   const { navbarState } = useNavbarContext();
   if (navbarState.type !== 'hovered') return <></>;
 
   return (
-    <div
-      className="absolute bottom-0 left-0 right-0 z-50 flex sm:hidden"
-      style={{ top: HEADER_HEIGHT_PX }}
-    >
+    <div className="absolute bottom-0 left-0 right-0 z-50 flex h-[68px] sm:hidden">
       <MobileNavList />
       <MobileNavDetail />
     </div>

--- a/components/layout/navbar/MobileNavDetail.tsx
+++ b/components/layout/navbar/MobileNavDetail.tsx
@@ -26,16 +26,14 @@ interface NavTreeProps {
 }
 
 const NavTree = ({ node, curNode, depth = 0 }: NavTreeProps) => {
-  const marginBottom = depth === 0 ? '1.75rem' : '1.5rem';
-
   return (
     <>
       {depth !== 0 && (
         <NavTreeLabel
           segmentNode={node}
           highlight={curNode === node}
-          marginBottom={marginBottom}
-          fontSize={depth === 1 ? 'text-md' : 'text-sm'}
+          containerClassName={depth === 0 ? 'mbn-[1.75rem]' : 'mb-[1.5rem]'}
+          anchorClassName={depth === 1 ? 'text-md' : 'text-sm'}
         />
       )}
       {0 < node.children.length && (

--- a/components/layout/navbar/Navbar.tsx
+++ b/components/layout/navbar/Navbar.tsx
@@ -17,7 +17,7 @@ export default function Navbar() {
 
   return (
     <div
-      className={`fixed bottom-0 left-0 top-0 z-50 hidden sm:flex`}
+      className="fixed bottom-0 left-0 top-0 z-50 hidden sm:flex"
       onMouseLeave={handleMouseLeave}
     >
       <NavbarRoot />

--- a/components/layout/navbar/NavbarDetail.tsx
+++ b/components/layout/navbar/NavbarDetail.tsx
@@ -25,12 +25,15 @@ interface NavTreeProps {
 }
 
 function NavTree({ node, curNode, depth = 0 }: NavTreeProps) {
-  const marginBottom = depth === 0 ? '1.75rem' : '1.5rem';
-
   return (
     <>
       {depth !== 0 && (
-        <NavTreeLabel segmentNode={node} highlight={curNode === node} marginBottom={marginBottom} />
+        <NavTreeLabel
+          segmentNode={node}
+          highlight={curNode === node}
+          containerClassName={depth === 0 ? 'mb-[1.75rem]' : 'mb-[1.5rem]'}
+          anchorClassName="text-md"
+        />
       )}
       {node.children !== null && 0 < node.children.length && (
         <div className="mb-11 ml-5">

--- a/components/layout/navbar/NavbarRoot.tsx
+++ b/components/layout/navbar/NavbarRoot.tsx
@@ -7,7 +7,6 @@ import DotEmpty from '@/public/image/navbar/dot_empty.svg';
 import DotFill from '@/public/image/navbar/dot_fill.svg';
 import SnuLogo from '@/public/image/SNU_Logo.svg';
 import useCurrentSegmentNode from '@/utils/hooks/useCurrentSegmentNode';
-import useStyle from '@/utils/hooks/useStyle';
 import { getPath, isAncestorNode } from '@/utils/page';
 
 export const NAVBAR_CLOSED_WIDTH_REM = 6.25;
@@ -19,12 +18,8 @@ export default function NavbarRoot() {
   return (
     // 상하로 화면이 좁은 경우를 대비해 overflow-scroll
     <div
-      className={`no-scrollbar z-50 flex w-[6.25rem] flex-col items-center overflow-scroll bg-[#323235] py-[2.88rem] transition-all duration-300 ease-in-out`}
+      className={`no-scrollbar z-50 flex flex-col items-center overflow-scroll bg-[#323235] py-[2.88rem] transition-all duration-300 ease-in-out ${navbarState.type === 'closed' ? 'w-[6.25rem]' : 'w-[11rem]'}`}
       onMouseEnter={() => setNavbarState({ type: 'expanded' })}
-      {...useStyle(
-        (style) => (style.width = navbarState.type === 'closed' ? '6.25rem' : '11rem'),
-        [navbarState.type],
-      )}
     >
       <Link href="/" aria-label="메인으로 이동">
         <SnuLogo className="fill-white" width="56" height="58" viewBox="0 0 45 47" />

--- a/components/layout/navbar/NavbarRoot.tsx
+++ b/components/layout/navbar/NavbarRoot.tsx
@@ -7,6 +7,7 @@ import DotEmpty from '@/public/image/navbar/dot_empty.svg';
 import DotFill from '@/public/image/navbar/dot_fill.svg';
 import SnuLogo from '@/public/image/SNU_Logo.svg';
 import useCurrentSegmentNode from '@/utils/hooks/useCurrentSegmentNode';
+import useStyle from '@/utils/hooks/useStyle';
 import { getPath, isAncestorNode } from '@/utils/page';
 
 export const NAVBAR_CLOSED_WIDTH_REM = 6.25;
@@ -14,14 +15,16 @@ export const NAVBAR_EXPANDED_WIDTH_REM = 11;
 
 export default function NavbarRoot() {
   const { navbarState, setNavbarState } = useNavbarContext();
-  const width = navbarState.type === 'closed' ? NAVBAR_CLOSED_WIDTH_REM : NAVBAR_EXPANDED_WIDTH_REM;
 
   return (
     // 상하로 화면이 좁은 경우를 대비해 overflow-scroll
     <div
-      className={`no-scrollbar z-50 flex flex-col items-center overflow-scroll bg-[#323235] py-[2.88rem] transition-all duration-300 ease-in-out`}
+      className={`no-scrollbar z-50 flex w-[6.25rem] flex-col items-center overflow-scroll bg-[#323235] py-[2.88rem] transition-all duration-300 ease-in-out`}
       onMouseEnter={() => setNavbarState({ type: 'expanded' })}
-      style={{ width: `${width}rem` }}
+      {...useStyle(
+        (style) => (style.width = navbarState.type === 'closed' ? '6.25rem' : '11rem'),
+        [navbarState.type],
+      )}
     >
       <Link href="/" aria-label="메인으로 이동">
         <SnuLogo className="fill-white" width="56" height="58" viewBox="0 0 45 47" />

--- a/components/layout/navbar/NavtreeRow.tsx
+++ b/components/layout/navbar/NavtreeRow.tsx
@@ -9,102 +9,46 @@ import { getPath } from '@/utils/page';
 type NavTreeRowProps = {
   segmentNode: SegmentNode;
   highlight: boolean;
-  marginBottom: string;
-  fontSize?: string;
+  containerClassName: string;
+  anchorClassName: string;
 };
 
 export default function NavTreeLabel({
   segmentNode,
   highlight,
-  marginBottom,
-  fontSize,
+  containerClassName,
+  anchorClassName,
 }: NavTreeRowProps) {
   const href = getPath(segmentNode);
 
   if (highlight) {
     return (
-      <HighlightedLabel
-        href={href}
-        text={segmentNode.name}
-        marginBottom={marginBottom}
-        fontSize={fontSize}
-      />
+      <div className={`flex items-center ${containerClassName}`}>
+        <Link
+          href={href}
+          className={`mr-4 h-[1.0625rem] shrink-0 font-medium text-main-orange ${anchorClassName}`}
+        >
+          <NavLabel text={segmentNode.name} />
+        </Link>
+        <StraightNode />
+      </div>
     );
   } else if (segmentNode.isPage) {
     return (
-      <LinkLabel
-        href={href}
-        text={segmentNode.name}
-        marginBottom={marginBottom}
-        fontSize={fontSize}
-      />
-    );
-  } else {
-    return <TextLabel text={segmentNode.name} marginBottom={marginBottom} fontSize={fontSize} />;
-  }
-}
-
-function HighlightedLabel({
-  href,
-  text,
-  marginBottom,
-  fontSize = 'text-md',
-}: {
-  href: string;
-  text: string;
-  marginBottom: string;
-  fontSize?: string;
-}) {
-  return (
-    <div className="flex items-center" style={{ marginBottom }}>
       <Link
         href={href}
-        className={`mr-4 h-[1.0625rem] shrink-0  font-medium text-main-orange ${fontSize}`}
+        className={`mb-6 block h-[1.0625rem] font-medium leading-5 text-white hover:text-main-orange ${anchorClassName} ${containerClassName}`}
       >
-        <NavLabel text={text} />
+        <NavLabel text={segmentNode.name} />
       </Link>
-      <StraightNode />
-    </div>
-  );
-}
-
-function LinkLabel({
-  href,
-  text,
-  marginBottom,
-  fontSize = 'text-md',
-}: {
-  href: string;
-  text: string;
-  marginBottom: string;
-  fontSize?: string;
-}) {
-  return (
-    <Link
-      href={href}
-      className={`mb-6 block h-[1.0625rem] font-medium leading-5 text-white hover:text-main-orange ${fontSize}`}
-      style={{ marginBottom }}
-    >
-      <NavLabel text={text} />
-    </Link>
-  );
-}
-
-function TextLabel({
-  text,
-  marginBottom,
-  fontSize = 'text-md',
-}: {
-  text: string;
-  marginBottom: string;
-  fontSize?: string;
-}) {
-  return (
-    <p
-      className={`mb-6 block h-[1.0625rem] font-medium leading-5 text-white ${fontSize}`}
-      style={{ marginBottom }}
-    >
-      <NavLabel text={text} />
-    </p>
-  );
+    );
+  } else {
+    return (
+      <p
+        className={`mb-6 block h-[1.0625rem] font-medium leading-5 text-white ${containerClassName} ${anchorClassName}`}
+      >
+        <NavLabel text={segmentNode.name} />
+      </p>
+    );
+  }
 }

--- a/components/layout/pageLayout/MajorCategoryPageLayout.tsx
+++ b/components/layout/pageLayout/MajorCategoryPageLayout.tsx
@@ -45,8 +45,9 @@ export default function MajorCategoryPageLayout({
         {description && (
           <HTMLViewer
             htmlContent={description}
-            style={{ color: '#f5f5f5', maxWidth: 960 }}
-            className="mb-6 mt-8 hidden sm:block"
+            wrapperClassName="mb-6 mt-8 hidden sm:block"
+            // contentClassName={{ color: '#f5f5f5', maxWidth: 960 }}
+            contentClassName="!text-[#f5f5f5] max-w-[960px]"
           />
         )}
       </div>
@@ -85,7 +86,7 @@ export default function MajorCategoryPageLayout({
         <div className="px-5 pb-24 pt-6 sm:hidden">
           <HTMLViewer
             htmlContent={description}
-            style={{ color: '#a3a3a3', fontWeight: 300, fontSize: 13 }}
+            contentClassName="!text-[#a3a3a3] font-light text-[13px]"
           />
         </div>
       )}

--- a/components/layout/pageLayout/PageLayout.tsx
+++ b/components/layout/pageLayout/PageLayout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { CSSProperties, type JSX, ReactNode } from 'react';
+import { type JSX, ReactNode } from 'react';
 
 import SubNavbar from '@/components/layout/pageLayout/SubNavbar';
 import useCurrentSegmentNode from '@/utils/hooks/useCurrentSegmentNode';
@@ -13,7 +13,7 @@ interface PageLayoutProps {
   title?: string | JSX.Element;
   titleType: 'big' | 'small';
   titleMargin?: string; // tailwind class
-  bodyStyle?: CSSProperties;
+  bodyClassName?: string;
   hideNavbar?: boolean;
   children: ReactNode;
 }
@@ -21,7 +21,7 @@ interface PageLayoutProps {
 export const PAGE_PADDING_LEFT_PX = 100;
 export const PAGE_PADDING_RIGHT_PX = 360;
 export const PAGE_PADDING_TOP_PX = 44;
-export const PAGE_PADDING_BOTTOM_PX = 150;
+export const PAGE_PADDING_BOTTOM_TAILWIND = '150px';
 
 /**
  * 본문 기본 스타일
@@ -36,7 +36,7 @@ export default function PageLayout({
   title,
   titleType,
   titleMargin = 'mb-6 sm:mb-11',
-  bodyStyle,
+  bodyClassName,
   hideNavbar = false,
   children,
 }: PageLayoutProps) {
@@ -54,8 +54,7 @@ export default function PageLayout({
         margin={titleMargin}
       />
       <div
-        className="relative grow bg-white p-[1.75rem_1.25rem_4rem_1.25rem] sm:p-[2.75rem_360px_150px_100px]"
-        style={bodyStyle}
+        className={`${bodyClassName ?? 'p-[1.75rem_1.25rem_4rem_1.25rem] sm:p-[2.75rem_360px_150px_100px]'} relative grow bg-white`}
       >
         {children}
         {!hideNavbar && <SubNavbar currentTab={currentPage} />}

--- a/components/layout/pageLayout/SubNavbar.tsx
+++ b/components/layout/pageLayout/SubNavbar.tsx
@@ -4,6 +4,7 @@ import { CurvedVerticalNode } from '@/components/common/Nodes';
 import NavLabel from '@/components/layout/navbar/NavLabel';
 import { SegmentNode } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
+import useStyle from '@/utils/hooks/useStyle';
 import { getAllSubTabs, getDepth, getPath, getRootTab } from '@/utils/page';
 
 type TreeNode = {
@@ -26,7 +27,7 @@ export default function SubNavbar({ currentTab }: { currentTab: TreeNode }) {
     <div className="absolute right-[80px] top-0 hidden h-full sm:block">
       <div
         className="sticky top-[52px] col-start-2 row-span-full mb-8 mt-[3.25rem] flex"
-        style={{ height }}
+        {...useStyle((style) => (style.height = height), [height])}
       >
         <CurvedVerticalNode grow={false} />
         <div className="pl-1.5 pt-[0.6875rem]">
@@ -57,7 +58,7 @@ function SubTab({ tab, isCurrent }: { tab: SegmentNode; isCurrent: boolean }) {
       className={`mb-3.5 w-fit text-sm ${
         isCurrent ? 'font-bold tracking-wider text-main-orange' : 'text-neutral-700'
       }`}
-      style={{ marginLeft }}
+      {...useStyle((style) => (style.marginLeft = marginLeft), [marginLeft])}
     >
       {tab.isPage ? (
         <Link href={getPath(tab)} className="whitespace-nowrap hover:text-main-orange">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'node:url';
 
 import { includeIgnoreFile } from '@eslint/compat';
 import pluginJs from '@eslint/js';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
 import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
@@ -34,7 +33,7 @@ export default [
   pluginReact.configs.flat.recommended,
   {
     rules: {
-      'react/forbid-component-props': [
+      'react/forbid-dom-props': [
         'warn',
         {
           forbid: [
@@ -72,6 +71,7 @@ export default [
         },
         {
           name: 'next/image',
+          importNames: ['default'],
           message: 'CSP 문제로 @/components/common/image를 사용해주세요.',
         },
       ],
@@ -85,13 +85,13 @@ export default [
       'unused-imports/no-unused-imports': 'error',
     },
   },
-  jsxA11y.flatConfigs.recommended,
-  {
-    rules: {
-      'jsx-a11y/label-has-associated-control': 'warn',
-      'jsx-a11y/click-events-have-key-events': 'warn',
-      'jsx-a11y/no-static-element-interactions': 'warn',
-      'jsx-a11y/no-noninteractive-element-interactions': 'warn',
-    },
-  },
+  // jsxA11y.flatConfigs.recommended,
+  // {
+  //   rules: {
+  //     'jsx-a11y/label-has-associated-control': 'warn',
+  //     'jsx-a11y/click-events-have-key-events': 'warn',
+  //     'jsx-a11y/no-static-element-interactions': 'warn',
+  //     'jsx-a11y/no-noninteractive-element-interactions': 'warn',
+  //   },
+  // },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -85,13 +85,13 @@ export default [
       'unused-imports/no-unused-imports': 'error',
     },
   },
-  // jsxA11y.flatConfigs.recommended,
-  // {
-  //   rules: {
-  //     'jsx-a11y/label-has-associated-control': 'warn',
-  //     'jsx-a11y/click-events-have-key-events': 'warn',
-  //     'jsx-a11y/no-static-element-interactions': 'warn',
-  //     'jsx-a11y/no-noninteractive-element-interactions': 'warn',
-  //   },
-  // },
+  jsxA11y.flatConfigs.recommended,
+  {
+    rules: {
+      'jsx-a11y/label-has-associated-control': 'warn',
+      'jsx-a11y/click-events-have-key-events': 'warn',
+      'jsx-a11y/no-static-element-interactions': 'warn',
+      'jsx-a11y/no-noninteractive-element-interactions': 'warn',
+    },
+  },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,22 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
+  {
+    rules: {
+      'react/forbid-component-props': [
+        'warn',
+        {
+          forbid: [
+            {
+              propName: 'style',
+              message:
+                'CSP 문제로 style prop은 직접 사용할 수 없습니다. tailwind className 혹은 useStyle을 사용하세요.',
+            },
+          ],
+        },
+      ],
+    },
+  },
   pluginReact.configs.flat['jsx-runtime'],
   {
     plugins: { 'react-hooks': pluginReactHooks, 'simple-import-sort': simpleImportSort },
@@ -43,7 +59,6 @@ export default [
   },
   {
     rules: {
-      // Consistently import navigation APIs from `@/i18n/routing`
       'no-restricted-imports': [
         'error',
         {
@@ -54,6 +69,10 @@ export default [
           name: 'next/navigation',
           importNames: ['redirect', 'permanentRedirect', 'useRouter', 'usePathname'],
           message: 'Please import from `@/i18n/routing` instead.',
+        },
+        {
+          name: 'next/image',
+          message: 'CSP 문제로 @/components/common/image를 사용해주세요.',
         },
       ],
     },

--- a/middleware.ts
+++ b/middleware.ts
@@ -35,7 +35,7 @@ export default async function middleware(request: NextRequest) {
     script-src 'self' ${
       isDev
         ? `'unsafe-inline' 'unsafe-eval' https://t1.daumcdn.net https://dapi.kakao.com`
-        : `'nonce-${nonce}' 'strict-dynamic' https://dapi.kakao.com`
+        : `'nonce-${nonce}' 'strict-dynamic' https://t1.daumcdn.net https://dapi.kakao.com`
     };
     style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com ${isDev ? `'unsafe-inline'` : `'nonce-${nonce}'`};
     img-src 'self' blob: data: https://t1.daumcdn.net https://map.daumcdn.net https://mts.daumcdn.net;

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,7 +22,7 @@ const generateCSPHeader = (nonce: string) =>
         ? `'nonce-${nonce}' 'strict-dynamic' https://dapi.kakao.com`
         : `'unsafe-inline' 'unsafe-eval' https://t1.daumcdn.net https://dapi.kakao.com`
     };
-    style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com;
+    style-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net https://fonts.googleapis.com;
     img-src 'self' blob: data: https://t1.daumcdn.net https://map.daumcdn.net https://mts.daumcdn.net https://cse-dev-waffle.bacchus.io/;
     font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com;
     object-src 'none';

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,28 +14,6 @@ const isAuthRequired = (pathname: string) => {
   return pathname.startsWith('/admin') || pathname.endsWith('create') || pathname.endsWith('edit');
 };
 
-const generateCSPHeader = (nonce: string) => {
-  const common = `'self' https://cse.snu.ac.kr https://cse-dev-waffle.bacchus.io/`;
-  return `
-    default-src 'self';
-    script-src 'self' ${
-      process.env.NODE_ENV === 'production'
-        ? `'nonce-${nonce}' 'strict-dynamic' https://dapi.kakao.com`
-        : `'unsafe-inline' 'unsafe-eval' https://t1.daumcdn.net https://dapi.kakao.com`
-    };
-    style-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net https://fonts.googleapis.com;
-    img-src blob: data: https://t1.daumcdn.net https://map.daumcdn.net https://mts.daumcdn.net ${common};
-    font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com;
-    object-src 'none';
-    base-uri 'self';
-    form-action 'self';
-    frame-ancestors 'none';
-    upgrade-insecure-requests;
-`
-    .replace(/\s{2,}/g, ' ')
-    .trim();
-};
-
 export default async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
@@ -52,7 +30,25 @@ export default async function middleware(request: NextRequest) {
   }
 
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
-  const cspHeader = generateCSPHeader(nonce);
+  const cspHeader = `
+    default-src 'self';
+    script-src 'self' ${
+      isDev
+        ? `'unsafe-inline' 'unsafe-eval' https://t1.daumcdn.net https://dapi.kakao.com`
+        : `'nonce-${nonce}' 'strict-dynamic' https://dapi.kakao.com`
+    };
+    style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com ${isDev ? `'unsafe-inline'` : `'nonce-${nonce}'`};
+    img-src 'self' blob: data: https://t1.daumcdn.net https://map.daumcdn.net https://mts.daumcdn.net;
+    font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com;
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+`
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);
   requestHeaders.set('Content-Security-Policy', cspHeader);

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,8 +14,9 @@ const isAuthRequired = (pathname: string) => {
   return pathname.startsWith('/admin') || pathname.endsWith('create') || pathname.endsWith('edit');
 };
 
-const generateCSPHeader = (nonce: string) =>
-  `
+const generateCSPHeader = (nonce: string) => {
+  const common = `'self' https://cse.snu.ac.kr https://cse-dev-waffle.bacchus.io/`;
+  return `
     default-src 'self';
     script-src 'self' ${
       process.env.NODE_ENV === 'production'
@@ -23,7 +24,7 @@ const generateCSPHeader = (nonce: string) =>
         : `'unsafe-inline' 'unsafe-eval' https://t1.daumcdn.net https://dapi.kakao.com`
     };
     style-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net https://fonts.googleapis.com;
-    img-src 'self' blob: data: https://t1.daumcdn.net https://map.daumcdn.net https://mts.daumcdn.net https://cse-dev-waffle.bacchus.io/;
+    img-src blob: data: https://t1.daumcdn.net https://map.daumcdn.net https://mts.daumcdn.net ${common};
     font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com;
     object-src 'none';
     base-uri 'self';
@@ -33,6 +34,7 @@ const generateCSPHeader = (nonce: string) =>
 `
     .replace(/\s{2,}/g, ' ')
     .trim();
+};
 
 export default async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-hook-form": "^7.53.2",
-        "react-hot-toast": "^2.4.1",
+        "react-toastify": "^10.0.6",
         "sharp": "^0.32.5",
         "suneditor": "^2.46.3",
         "tailwindcss": "3.3.2"
@@ -7072,13 +7072,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/goober": {
-      "version": "2.1.13",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "license": "MIT",
@@ -10250,23 +10243,22 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
-    "node_modules/react-hot-toast": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "goober": "^2.1.10"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-hook-form": "^7.53.2",
-    "react-hot-toast": "^2.4.1",
+    "react-toastify": "^10.0.6",
     "sharp": "^0.32.5",
     "suneditor": "^2.46.3",
     "tailwindcss": "3.3.2"

--- a/server.mjs
+++ b/server.mjs
@@ -14,8 +14,8 @@ switch (phase) {
     process.env.BASE_URL = 'http://localhost:8080/api';
     break;
   case 'beta':
-    process.env.BUILD_VERSION = execSync('git rev-parse --short HEAD').toString();
     process.env.BASE_URL = 'http://localhost:8080/api';
+    process.env.BUILD_VERSION = execSync('git rev-parse --short HEAD').toString();
     break;
   case 'local':
     process.env.BASE_URL = 'https://cse-dev-waffle.bacchus.io/api';

--- a/utils/hooks/useStyle.ts
+++ b/utils/hooks/useStyle.ts
@@ -1,0 +1,19 @@
+import { useLayoutEffect, useRef } from 'react';
+
+const useStyle = <T extends HTMLElement>(
+  setStyle: (style: CSSStyleDeclaration) => void,
+  deps: unknown[],
+) => {
+  const ref = useRef<T>(null);
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      setStyle(ref.current.style);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deps]);
+
+  return { ref };
+};
+
+export default useStyle;

--- a/utils/toast.ts
+++ b/utils/toast.ts
@@ -1,4 +1,4 @@
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 
 export const successToast = (message: string) => {
   toast.success(message, {


### PR DESCRIPTION
## 작업 요약

스타일 관련된 CSP 에러들을 수정합니다.

## 상세 내용

- ESLint 설정 추가
  - style attribute 사용 금지
  - next/image 사용 금지
- react-hot-toast를 react-toastify로 대체
  - 디자인 관련 작업 필요
  - https://github.com/timolins/react-hot-toast/issues/138
- style attribute 대신 `useStyle` 사용
  - style attr를 next에서 SSR해서 style attr가 포함된 HTML을 만드는 문제가 있었음
  - 기존에 style attr를 사용하는 코드는 useLayoutEffect를 활용하여 런타임 시점으로 미룸 
  - tailwind를 통해 className으로 스타일을 지정하는 방식은 CSS 파일을 사용하는 것이라 CSP에 걸리지 않음
  - JS 실행 후 스타일이 적용되면서 깜빡거리는 문제가 있어서 추후에 수정 필요. tailwind로 초기값 전달해주는 처리 필요.
- next/image 대신 래핑된 이미지 컴포넌트 사용
  - https://github.com/vercel/next.js/issues/45184

## 테스트 방법

나중에 전체 QA 필요...

CornerFoldedRectangle이나 서브네비처럼 스타일이 많이 쓰인 컴포넌트들 확인 필요.

## 참고 문서

.
