### PR TITLE
🔒️ HTMLViewer의 CSP 문제 수정

### DIFF
--- a/apis/v2/academics/scholarship/index.ts
+++ b/apis/v2/academics/scholarship/index.ts
@@ -2,7 +2,7 @@ import { putRequest } from '@/apis';
 import { Scholarship } from '@/apis/types/academics';
 import { WithLanguage } from '@/types/language';
 
-export const putScholarship = async (id: number, data: WithLanguage<Scholarship>) =>
+export const putScholarship = async (_id: number, data: WithLanguage<Scholarship>) =>
   putRequest(`/v2/academics/scholarship`, {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),

--- a/app/[locale]/people/components/PeopleCell.tsx
+++ b/app/[locale]/people/components/PeopleCell.tsx
@@ -24,8 +24,7 @@ export default function PeopleCell({
     <article className="group flex w-fit flex-row gap-5 text-md sm:w-36 sm:flex-col sm:gap-3">
       <Link
         href={href}
-        className="relative h-48 w-36 shrink-0 cursor-pointer overflow-hidden "
-        style={{ filter: 'drop-shadow(0px 0px 4px rgba(0,0,0,0.15))' }}
+        className="relative h-48 w-36 shrink-0 cursor-pointer overflow-hidden drop-shadow-[0px_0px_4px_rgba(0,0,0,0.15)]"
         aria-label={`${title} 교수 상세 페이지로 이동`}
       >
         <ImageWithFallback

--- a/app/[locale]/people/components/ProfileImage.tsx
+++ b/app/[locale]/people/components/ProfileImage.tsx
@@ -1,5 +1,7 @@
 import ImageWithFallback from '@/components/common/ImageWithFallback';
 
+import styles from './style.module.css';
+
 export default function ProfileImage({ imageURL }: { imageURL: string | null }) {
   return (
     <ImageWithFallback
@@ -7,12 +9,8 @@ export default function ProfileImage({ imageURL }: { imageURL: string | null }) 
       src={imageURL}
       width={200}
       height={264}
-      className="object-contain"
+      className={`object-contain ${styles.memberImage}`}
       sizes="186px, 248px"
-      style={{
-        clipPath: 'polygon(84.375% 0%, 100% 11.71875%, 100% 100%, 0% 100%, 0% 0%)',
-        filter: 'drop-shadow(0px 0px 4px rgba(0,0,0,0.15))',
-      }}
     />
   );
 }

--- a/app/[locale]/people/components/style.module.css
+++ b/app/[locale]/people/components/style.module.css
@@ -1,0 +1,4 @@
+.profileImage {
+  clip-path: polygon(84.375% 0%, 100% 11.71875%, 100% 100%, 0% 100%, 0% 0%);
+  filter: drop-shadow(0px 0px 4px rgba(0, 0, 0, 0.15));
+}

--- a/app/[locale]/search/MemberSection.tsx
+++ b/app/[locale]/search/MemberSection.tsx
@@ -7,6 +7,7 @@ import { getPath } from '@/utils/page';
 import CircleTitle from './helper/CircleTitle';
 import Divider from './helper/Divider';
 import Section from './helper/Section';
+import styles from './style.module.css';
 
 export default async function MemberSection({ member }: { member: MemberSearchResult }) {
   const professorList = member.results.filter((x) => x.memberType === 'PROFESSOR');
@@ -50,15 +51,11 @@ const MemberCell = ({ name, academicRankOrRole, imageURL, memberType, id }: Memb
       <ImageWithFallback
         src={imageURL}
         alt={`${name} 프로필`}
-        className="h-[192px] w-[144px] object-cover"
+        className={`h-[192px] w-[144px] object-cover ${styles.memberImage}`}
         width={144}
         height={192}
         quality={50}
         priority
-        style={{
-          clipPath: 'polygon(84.375% 0%, 100% 11.71875%, 100% 100%, 0% 100%, 0% 0%)',
-          filter: 'drop-shadow(0px 0px 4px rgba(0,0,0,0.15))',
-        }}
       />
       <div className="flex items-end gap-1">
         <h3 className="text-[1.04169rem] font-bold text-neutral-950 group-hover:underline">

--- a/app/[locale]/search/style.module.css
+++ b/app/[locale]/search/style.module.css
@@ -1,0 +1,4 @@
+.memberImage {
+  clip-path: polygon(84.375% 0%, 100% 11.71875%, 100% 100%, 0% 100%, 0% 0%);
+  filter: drop-shadow(0px 0px 4px rgba(0, 0, 0, 0.15));
+}

--- a/components/common/ImageWithFallback.tsx
+++ b/components/common/ImageWithFallback.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CSSProperties, useState } from 'react';
+import { useState } from 'react';
 
 import Image from '@/components/common/Image';
 import SnuLogo from '@/public/image/SNU_Logo.svg';
@@ -55,5 +55,4 @@ interface ImageWithFallbackProps {
   fill?: boolean | undefined;
   priority?: boolean | undefined;
   quality?: number;
-  style?: CSSProperties;
 }

--- a/components/form/Date.tsx
+++ b/components/form/Date.tsx
@@ -48,7 +48,7 @@ export default function DateSelector({
             <Dropdown
               contents={Array(24)
                 .fill(0)
-                .map((x, i) => (i + '').padStart(2, '0') + '시')}
+                .map((_x, i) => (i + '').padStart(2, '0') + '시')}
               selectedIndex={date.getHours()}
               onClick={(idx) => {
                 const newDate = new Date(date);
@@ -107,4 +107,4 @@ const formatDate = (date: Date) => {
 
 const minuteDropdownContent = Array(4)
   .fill(0)
-  .map((x, i) => (i * 15 + '').padStart(2, '0') + '분');
+  .map((_x, i) => (i * 15 + '').padStart(2, '0') + '분');

--- a/components/form/html/HTMLEditor.tsx
+++ b/components/form/html/HTMLEditor.tsx
@@ -48,7 +48,7 @@ export default function HTMLEditor({ name, options: registerOptions }: HTMLEdito
 }
 
 // @ts-expect-error suneditor 내부 타입
-const handleImageUploadBefore = (files, info, core, uploadHandler) => {
+const handleImageUploadBefore = (files, _info, _core, uploadHandler) => {
   const formData = new FormData();
   // @ts-expect-error suneditor 내부 타입
   files.forEach((file, idx) => {

--- a/components/form/html/HTMLHydrator.tsx
+++ b/components/form/html/HTMLHydrator.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useLayoutEffect } from 'react';
+
+export default function HTMLHydrator() {
+  useLayoutEffect(() => {
+    const elements = document.querySelectorAll('[data-style]');
+    elements.forEach((el) => {
+      const style = el.getAttribute('data-style');
+      if (style) (el as HTMLElement).style.cssText = style;
+    });
+  }, []);
+
+  return null;
+}

--- a/components/form/html/HTMLViewer.tsx
+++ b/components/form/html/HTMLViewer.tsx
@@ -1,15 +1,11 @@
-// useMediaQuery가 nextjs15부터 서버단에서 사용하면 에러가 발생해 use client 처리
-// TODO: use client 제거
-'use client';
-
 import './suneditor-contents.css';
 
 import { Autolinker } from 'autolinker';
+import parse, { DOMNode, Element } from 'html-react-parser';
 import { ReactNode } from 'react';
 
-import ImageWithFallback from '@/components/common/ImageWithFallback';
-import useResponsive from '@/utils/hooks/useResponsive';
-import useStyle from '@/utils/hooks/useStyle';
+import HTMLHydrator from '@/components/form/html/HTMLHydrator';
+import TopRightImageContent, { TopRightImage } from '@/components/form/html/TopRightImage';
 
 interface TopRightComponent {
   type: 'component';
@@ -34,54 +30,25 @@ export default function HTMLViewer({
   // 400.XXX같은 값들이 링크 처리되는걸 막기 위해 tldMatches false처리
   const linkedHTML = Autolinker.link(htmlContent, { urls: { tldMatches: false } });
 
+  const replace = (domNode: DOMNode) => {
+    if (domNode instanceof Element && domNode.attribs) {
+      const { style, ...rest } = domNode.attribs;
+      domNode.attribs = rest;
+      domNode.attribs['data-style'] = style;
+    }
+    return domNode;
+  };
+
   return (
     <div className={`flow-root ${wrapperClassName}`}>
       {topRightContent?.type === 'image' && <TopRightImageContent {...topRightContent} />}
-      {topRightContent?.type === 'component' && <TopRightComponent {...topRightContent} />}
-      <div
-        className={`sun-editor-editable ${contentClassName}`}
-        dangerouslySetInnerHTML={{ __html: linkedHTML }}
-      />
-    </div>
-  );
-}
-
-function TopRightComponent({ content }: TopRightComponent) {
-  return <div className="relative float-right">{content}</div>;
-}
-
-type TopRightImage = {
-  type: 'image';
-  url: string;
-  widthPX: number;
-  heightPX: number;
-  marginTopPx?: number;
-  mobileFullWidth?: boolean;
-};
-
-function TopRightImageContent(props: TopRightImage) {
-  const { isMobile } = useResponsive();
-  const { url, widthPX: width, heightPX: height, marginTopPx: marginTop } = props;
-
-  return (
-    <div
-      className="relative mb-7 w-full sm:float-right sm:ml-7 sm:w-auto"
-      {...useStyle(
-        (style) => {
-          style.width = isMobile && props.mobileFullWidth ? '' : `${width}px`;
-          style.marginTop = `${marginTop}px`;
-        },
-        [isMobile, props.mobileFullWidth, marginTop],
+      {topRightContent?.type === 'component' && (
+        <div className="relative float-right">{topRightContent.content}</div>
       )}
-    >
-      <ImageWithFallback
-        src={url}
-        alt="대표 이미지"
-        width={width}
-        height={height}
-        className="w-full object-contain"
-        sizes={`${width}px`}
-      />
+      <div className={`sun-editor-editable ${contentClassName}`}>
+        {parse(linkedHTML, { replace })}
+        <HTMLHydrator />
+      </div>
     </div>
   );
 }

--- a/components/form/html/TopRightImage.tsx
+++ b/components/form/html/TopRightImage.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import ImageWithFallback from '@/components/common/ImageWithFallback';
+import useResponsive from '@/utils/hooks/useResponsive';
+import useStyle from '@/utils/hooks/useStyle';
+
+export type TopRightImage = {
+  type: 'image';
+  url: string;
+  widthPX: number;
+  heightPX: number;
+  marginTopPx?: number;
+  mobileFullWidth?: boolean;
+};
+
+export default function TopRightImageContent(props: TopRightImage) {
+  const { isMobile } = useResponsive();
+  const { url, widthPX: width, heightPX: height, marginTopPx: marginTop } = props;
+
+  return (
+    <div
+      className="relative mb-7 w-full sm:float-right sm:ml-7 sm:w-auto"
+      {...useStyle(
+        (style) => {
+          style.width = isMobile && props.mobileFullWidth ? '' : `${width}px`;
+          style.marginTop = `${marginTop}px`;
+        },
+        [isMobile, props.mobileFullWidth, marginTop],
+      )}
+    >
+      <ImageWithFallback
+        src={url}
+        alt="대표 이미지"
+        width={width}
+        height={height}
+        className="w-full object-contain"
+        sizes={`${width}px`}
+      />
+    </div>
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -97,4 +97,22 @@ export default [
       'unused-imports/no-unused-imports': 'error',
     },
   },
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        // _으로 시작하는 변수는 허용
+        // https://typescript-eslint.io/rules/no-unused-vars/
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
+    },
+  },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,18 @@ export default [
           ],
         },
       ],
+      'react/forbid-component-props': [
+        'warn',
+        {
+          forbid: [
+            {
+              propName: 'style',
+              message:
+                'CSP 문제로 style prop은 직접 사용할 수 없습니다. tailwind className 혹은 useStyle을 사용하세요.',
+            },
+          ],
+        },
+      ],
     },
   },
   pluginReact.configs.flat['jsx-runtime'],
@@ -83,15 +95,6 @@ export default [
     },
     rules: {
       'unused-imports/no-unused-imports': 'error',
-    },
-  },
-  jsxA11y.flatConfigs.recommended,
-  {
-    rules: {
-      'jsx-a11y/label-has-associated-control': 'warn',
-      'jsx-a11y/click-events-have-key-events': 'warn',
-      'jsx-a11y/no-static-element-interactions': 'warn',
-      'jsx-a11y/no-noninteractive-element-interactions': 'warn',
     },
   },
 ];

--- a/middleware.ts
+++ b/middleware.ts
@@ -37,7 +37,7 @@ export default async function middleware(request: NextRequest) {
         ? `'unsafe-inline' 'unsafe-eval' https://t1.daumcdn.net https://dapi.kakao.com`
         : `'nonce-${nonce}' 'strict-dynamic' https://t1.daumcdn.net https://dapi.kakao.com`
     };
-    style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com ${isDev ? `'unsafe-inline'` : `'nonce-${nonce}'`};
+    style-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net https://fonts.googleapis.com;
     img-src 'self' blob: data: https://t1.daumcdn.net https://map.daumcdn.net https://mts.daumcdn.net;
     font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com;
     object-src 'none';

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "bezier-easing": "^2.1.0",
         "express": "^4.19.2",
         "file-loader": "^6.2.0",
+        "html-react-parser": "^5.2.1",
         "next": "15.0.4",
         "next-intl": "^3.26.0",
         "next-sitemap": "^4.2.3",
@@ -7264,6 +7265,56 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.12.tgz",
+      "integrity": "sha512-LP2BI8aCnv6HCnO1kyQMaycqL7RCTUODGFWdKwrlc6ROG5rtbVEtE4mkBn1tokBMflUN7wyNKL4AXq7EMmga6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.1.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.1.tgz",
+      "integrity": "sha512-4FZBYVzmlYzmNgoDVETZd/I/OnVR0d46UMnLdf/VdKTE973jImSfbonIRCov/AQQsL7zp7D1UKqMz0gbK6M0yA==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.12",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.16"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "license": "MIT",
@@ -7393,6 +7444,12 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -10247,6 +10304,12 @@
       "version": "16.13.1",
       "license": "MIT"
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
+    },
     "node_modules/react-toastify": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
@@ -11606,6 +11669,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
+      "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.8"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
+      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bezier-easing": "^2.1.0",
     "express": "^4.19.2",
     "file-loader": "^6.2.0",
+    "html-react-parser": "^5.2.1",
     "next": "15.0.4",
     "next-intl": "^3.26.0",
     "next-sitemap": "^4.2.3",

--- a/public/image/calendar.svg
+++ b/public/image/calendar.svg
@@ -1,5 +1,5 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_6117_130216" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+<mask id="mask0_6117_130216" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
 <rect width="20" height="20" fill="#D9D9D9"/>
 </mask>
 <g mask="url(#mask0_6117_130216)">

--- a/public/image/distance.svg
+++ b/public/image/distance.svg
@@ -1,5 +1,5 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_6117_117142" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+<mask id="mask0_6117_117142" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
 <rect width="20" height="20" fill="#D9D9D9"/>
 </mask>
 <g mask="url(#mask0_6117_117142)">

--- a/public/image/header/menu.svg
+++ b/public/image/header/menu.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_6184_7470" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<mask id="mask0_6184_7470" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
 <rect width="24" height="24" fill="#D9D9D9"/>
 </mask>
 <g mask="url(#mask0_6184_7470)">

--- a/public/image/person.svg
+++ b/public/image/person.svg
@@ -1,5 +1,5 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_6117_130207" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+<mask id="mask0_6117_130207" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
 <rect width="20" height="20" fill="#D9D9D9"/>
 </mask>
 <g mask="url(#mask0_6117_130207)">


### PR DESCRIPTION
## 작업 요약

- Link, Image등의 컴포넌트에서 style prop 금지
- HTMLViewer의 CSP 대응
- (PR과는 무관하지만) no-unused-vars 추가

## 상세 내용

브라우저에서 Raw HTML을 렌더링할 때 style 속성이 포함되어있으면 CSP 관련 에러가 발생합니다. 따라서 서버단에서는 html-react-parser를 사용해 style 속성을 제거해 data-style 속성에 백업해두고, 브라우저에서는 useLayoutEffect에서 data-style을 style로 복구시킵니다.

## 테스트 방법

새소식 등 게시물 볼 때 에러 미발생. 

## 참고 문서

https://github.com/remarkablemark/html-react-parser
