### PR TITLE
🐛 연구 검수

### DIFF
--- a/app/[locale]/research/centers/ResearchCenterDetails.tsx
+++ b/app/[locale]/research/centers/ResearchCenterDetails.tsx
@@ -9,10 +9,8 @@ import HTMLViewer from '@/components/form/html/HTMLViewer';
 import { researchCenters } from '@/constants/segmentNode';
 import LinkIcon from '@/public/image/link_icon.svg';
 import { WithLanguage } from '@/types/language';
-import { errorToStr } from '@/utils/error';
 import { getPath } from '@/utils/page';
-import { handleServerAction } from '@/utils/serverActionError';
-import { errorToast, successToast } from '@/utils/toast';
+import { handleServerResponse } from '@/utils/serverActionError';
 
 interface ResearchCenterDetailsProps {
   center: ResearchCenter;
@@ -23,12 +21,8 @@ const centersPath = getPath(researchCenters);
 
 export default function ResearchCenterDetails({ center, ids }: ResearchCenterDetailsProps) {
   const handleDelete = async () => {
-    try {
-      handleServerAction(await deleteResearchCenterAction(ids));
-      successToast('연구 센터를 삭제했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await deleteResearchCenterAction(ids);
+    handleServerResponse(resp, { successMessage: '연구 센터를 삭제했습니다.' });
   };
 
   return (

--- a/app/[locale]/research/centers/create/page.tsx
+++ b/app/[locale]/research/centers/create/page.tsx
@@ -2,22 +2,16 @@
 
 import { postResearchCenterAction } from '@/actions/research';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { errorToStr } from '@/utils/error';
 import { contentToFormData } from '@/utils/formData';
-import { handleServerAction } from '@/utils/serverActionError';
-import { errorToast, successToast } from '@/utils/toast';
+import { handleServerResponse } from '@/utils/serverActionError';
 
 import ResearchCenterEditor, { ResearchCenterFormData } from '../components/ResearchCenterEditor';
 
 export default function ResearchCenterCreatePage() {
   const onSubmit = async ({ image, ...requestObject }: ResearchCenterFormData) => {
     const formData = contentToFormData('CREATE', { requestObject, image });
-    try {
-      handleServerAction(await postResearchCenterAction(formData));
-      successToast('연구 센터를 추가했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await postResearchCenterAction(formData);
+    handleServerResponse(resp, { successMessage: '연구 센터를 추가했습니다.' });
   };
 
   return (

--- a/app/[locale]/research/centers/edit/ResearchCenterEditPageContent.tsx
+++ b/app/[locale]/research/centers/edit/ResearchCenterEditPageContent.tsx
@@ -4,10 +4,8 @@ import { putResearchCenterAction } from '@/actions/research';
 import { ResearchCenter } from '@/apis/types/research';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { WithLanguage } from '@/types/language';
-import { errorToStr } from '@/utils/error';
 import { contentToFormData } from '@/utils/formData';
-import { handleServerAction } from '@/utils/serverActionError';
-import { errorToast, successToast } from '@/utils/toast';
+import { handleServerResponse } from '@/utils/serverActionError';
 
 import ResearchCenterEditor, { ResearchCenterFormData } from '../components/ResearchCenterEditor';
 
@@ -18,14 +16,8 @@ export default function ResearchCenterEditPageContent({
 }) {
   const onSubmit = async ({ image, ...requestObject }: ResearchCenterFormData) => {
     const formData = contentToFormData('EDIT', { requestObject, image });
-    try {
-      handleServerAction(
-        await putResearchCenterAction({ ko: center.ko.id, en: center.en.id }, formData),
-      );
-      successToast('연구 센터를 수정했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await putResearchCenterAction({ ko: center.ko.id, en: center.en.id }, formData);
+    handleServerResponse(resp, { successMessage: '연구 센터를 수정했습니다.' });
   };
 
   return (

--- a/app/[locale]/research/groups/ResearchGroupDetails.tsx
+++ b/app/[locale]/research/groups/ResearchGroupDetails.tsx
@@ -10,10 +10,8 @@ import LoginVisible from '@/components/common/LoginVisible';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
 import { researchGroups } from '@/constants/segmentNode';
 import { WithLanguage } from '@/types/language';
-import { errorToStr } from '@/utils/error';
 import { getPath } from '@/utils/page';
-import { handleServerAction } from '@/utils/serverActionError';
-import { errorToast, successToast } from '@/utils/toast';
+import { handleServerResponse } from '@/utils/serverActionError';
 
 import ResearchGroupLabs from './ResearchGroupLabs';
 
@@ -28,12 +26,8 @@ export default function ResearchGroupDetails({ group, ids }: ResearchGroupDetail
   const t = useTranslations('Content');
 
   const handleDelete = async () => {
-    try {
-      handleServerAction(await deleteResearchGroupAction(ids));
-      successToast('연구 스트림을 삭제했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await deleteResearchGroupAction(ids);
+    handleServerResponse(resp, { successMessage: '연구 스트림을 삭제했습니다.' });
   };
 
   return (

--- a/app/[locale]/research/groups/create/page.tsx
+++ b/app/[locale]/research/groups/create/page.tsx
@@ -2,22 +2,16 @@
 
 import { postResearchGroupAction } from '@/actions/research';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { errorToStr } from '@/utils/error';
 import { contentToFormData } from '@/utils/formData';
-import { handleServerAction } from '@/utils/serverActionError';
-import { errorToast, successToast } from '@/utils/toast';
+import { handleServerResponse } from '@/utils/serverActionError';
 
 import ResearchGroupEditor, { ResearchGroupFormData } from '../components/ResearchGroupEditor';
 
 export default function ResearchGroupCreatePage() {
   const onSubmit = async ({ image, ...requestObject }: ResearchGroupFormData) => {
     const formData = contentToFormData('CREATE', { requestObject, image });
-    try {
-      handleServerAction(await postResearchGroupAction(formData));
-      successToast('연구 스트림을 추가했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await postResearchGroupAction(formData);
+    handleServerResponse(resp, { successMessage: '연구 스트림을 추가했습니다.' });
   };
 
   return (

--- a/app/[locale]/research/groups/edit/ResearchGroupEditPageContent.tsx
+++ b/app/[locale]/research/groups/edit/ResearchGroupEditPageContent.tsx
@@ -4,10 +4,8 @@ import { putResearchGroupAction } from '@/actions/research';
 import { ResearchGroup } from '@/apis/types/research';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { WithLanguage } from '@/types/language';
-import { errorToStr } from '@/utils/error';
 import { contentToFormData } from '@/utils/formData';
-import { handleServerAction } from '@/utils/serverActionError';
-import { errorToast, successToast } from '@/utils/toast';
+import { handleServerResponse } from '@/utils/serverActionError';
 
 import ResearchGroupEditor, { ResearchGroupFormData } from '../components/ResearchGroupEditor';
 
@@ -23,14 +21,8 @@ export default function ResearchGroupEditPageContent({
       image: content.image,
     });
 
-    try {
-      handleServerAction(
-        await putResearchGroupAction({ ko: group.ko.id, en: group.en.id }, formData),
-      );
-      successToast('연구 스트림을 수정했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await putResearchGroupAction({ ko: group.ko.id, en: group.en.id }, formData);
+    handleServerResponse(resp, { successMessage: '연구 스트림을 수정했습니다.' });
   };
 
   const defaultValues: ResearchGroupFormData = {

--- a/app/[locale]/research/labs/[id]/ResearchLabDetailContent.tsx
+++ b/app/[locale]/research/labs/[id]/ResearchLabDetailContent.tsx
@@ -12,12 +12,10 @@ import { Link } from '@/i18n/routing';
 import PentagonLong from '@/public/image/pentagon_long.svg';
 import PentagonShort from '@/public/image/pentagon_short.svg';
 import { WithLanguage } from '@/types/language';
-import { errorToStr } from '@/utils/error';
 import useResponsive from '@/utils/hooks/useResponsive';
 import { getPath } from '@/utils/page';
-import { handleServerAction } from '@/utils/serverActionError';
+import { handleServerResponse } from '@/utils/serverActionError';
 import { replaceSpaceWithDash } from '@/utils/string';
-import { errorToast, successToast } from '@/utils/toast';
 
 import ResearchLabInfo from './ResesarchLabInfo';
 
@@ -33,12 +31,8 @@ export default function ResearchLabDetailContent({
   const { isMobile } = useResponsive();
 
   const handleDelete = async () => {
-    try {
-      handleServerAction(await deleteResearchLabAction(ids));
-      successToast('연구실을 삭제했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await deleteResearchLabAction(ids);
+    handleServerResponse(resp, { successMessage: '연구실을 삭제했습니다.' });
   };
 
   return (

--- a/app/[locale]/research/labs/[id]/edit/ResearchLabEditPageContent.tsx
+++ b/app/[locale]/research/labs/[id]/edit/ResearchLabEditPageContent.tsx
@@ -9,10 +9,8 @@ import ResearchLabEditor, {
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { isLocalFile } from '@/types/form';
 import { WithLanguage } from '@/types/language';
-import { errorToStr } from '@/utils/error';
-import { handleServerAction } from '@/utils/serverActionError';
+import { handleServerResponse } from '@/utils/serverActionError';
 import { encodeFormDataFileName } from '@/utils/string';
-import { errorToast, successToast } from '@/utils/toast';
 
 interface ResearchLabEditPageContentProps {
   lab: WithLanguage<ResearchLab>;
@@ -52,18 +50,15 @@ export default function ResearchLabEditPageContent({
       ),
     );
 
+    // attachment가 아닌 특수한 key('pdf')라서 conentToFormData 사용하지 않고 직접 별도 처리
     encodeFormDataFileName(
       formData,
       'pdf',
       common.pdf.filter(isLocalFile).map((x) => x.file),
     );
 
-    try {
-      handleServerAction(await putResearchLabAction({ ko: lab.ko.id, en: lab.en.id }, formData));
-      successToast('연구실을 수정했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await putResearchLabAction({ ko: lab.ko.id, en: lab.en.id }, formData);
+    handleServerResponse(resp, { successMessage: '연구실을 수정했습니다.' });
   };
 
   const defaultValues: ResearchLabFormData = {

--- a/app/[locale]/research/labs/components/ResearchLabEditor.tsx
+++ b/app/[locale]/research/labs/components/ResearchLabEditor.tsx
@@ -5,15 +5,14 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { SimpleFaculty } from '@/apis/types/people';
 import { ResearchGroup } from '@/apis/types/research';
+import Fieldset from '@/components/form/Fieldset';
+import Form from '@/components/form/Form';
+import LanguagePicker from '@/components/form/LanguagePicker';
 import { researchLabs } from '@/constants/segmentNode';
 import { useRouter } from '@/i18n/routing';
+import { EditorFile } from '@/types/form';
 import { Language, WithLanguage } from '@/types/language';
 import { getPath } from '@/utils/page';
-
-import Fieldset from '../../../../../components/form/Fieldset';
-import Form from '../../../../../components/form/Form';
-import LanguagePicker from '../../../../../components/form/LanguagePicker';
-import { EditorFile } from '../../../../../types/form';
 
 export type ResearchLabFormData = WithLanguage<{
   name: string;

--- a/app/[locale]/research/labs/components/ResearchLabEditor.tsx
+++ b/app/[locale]/research/labs/components/ResearchLabEditor.tsx
@@ -108,6 +108,8 @@ const Editor = ({
               { label: '선택 안 함', value: null },
               ...professors[language].map((prof) => ({ label: prof.name, value: prof.id })),
             ]}
+            borderStyle="border-neutral-300"
+            height="h-8"
           />
         </Fieldset>
         <Fieldset title="연구실 약자" mb="mb-11" titleMb="mb-2">
@@ -139,6 +141,8 @@ const Editor = ({
             ...groups[language].map((lab) => ({ label: `${lab.name} 스트림`, value: lab.id })),
           ]}
           rules={{ required: true }}
+          borderStyle="border-neutral-300"
+          height="h-8"
         />
       </Fieldset>
 

--- a/app/[locale]/research/labs/create/ResearchLabCreatePageContent.tsx
+++ b/app/[locale]/research/labs/create/ResearchLabCreatePageContent.tsx
@@ -9,10 +9,8 @@ import ResearchLabEditor, {
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { isLocalFile } from '@/types/form';
 import { WithLanguage } from '@/types/language';
-import { errorToStr } from '@/utils/error';
-import { handleServerAction } from '@/utils/serverActionError';
+import { handleServerResponse } from '@/utils/serverActionError';
 import { encodeFormDataFileName } from '@/utils/string';
-import { errorToast, successToast } from '@/utils/toast';
 
 interface ResearchLabCreatePageContentProps {
   groups: WithLanguage<ResearchGroup[]>;
@@ -38,18 +36,15 @@ export default function ResearchLabCreatePageContent({
       ),
     );
 
+    // attachment가 아닌 특수한 key('pdf')라서 conentToFormData 사용하지 않고 직접 별도 처리
     encodeFormDataFileName(
       formData,
       'pdf',
       common.pdf.filter(isLocalFile).map((x) => x.file),
     );
 
-    try {
-      handleServerAction(await postResearchLabAction(formData));
-      successToast('연구실을 추가했습니다.');
-    } catch (e) {
-      errorToast(errorToStr(e));
-    }
+    const resp = await postResearchLabAction(formData);
+    handleServerResponse(resp, { successMessage: '연구실을 추가했습니다.' });
   };
 
   return (

--- a/components/layout/pageLayout/PageLayout.tsx
+++ b/components/layout/pageLayout/PageLayout.tsx
@@ -58,8 +58,8 @@ export default function PageLayout({
       <div
         className={clsx('relative grow bg-white', {
           'p-0': removePadding,
-          'pt-0': removeTopPadding,
-          'pb-0': removeBottomPadding,
+          'p-[0_1.25rem_4rem_1.25rem] sm:p-[0_360px_150px_100px]': removeTopPadding,
+          'p-[1.75rem_1.25rem_0_1.25rem] sm:p-[2.75rem_360px_0_100px]': removeBottomPadding,
           'p-[1.75rem_1.25rem_4rem_1.25rem] sm:p-[2.75rem_360px_150px_100px]':
             !removePadding && !removeTopPadding && !removeBottomPadding,
         })}


### PR DESCRIPTION
## 작업 요약

- 레거시 코드 정리
- 페이지 레이아웃 스타일 보완
- 연구실 에디터 스타일 보완 

## 상세 내용

- deprecated된 `handleServerAction` 대신 `handleServerResponse` 사용
- `PageLayout`에서 `removeTopPadding`이나 `removeBottomPadding`을 했을 때 해당 방향의 패딩만 없어지고 좌우패딩은 그대로 유지되도록 수정
- `ResearchLabEditor` 드롭다운 border 색상 및 height 지정

## 테스트 방법

- 각종 편집 기능이 기존처럼 정상적으로 동작하는지 확인
- 연구 센터 페이지 패딩이 올바르게 들어가 있는지 확인
- 연구실 편집 페이지의 드롭다운 스타일이 다른 텍스트 필드와 동일한지 확인

## 참고 문서


