### PR TITLE
🐛 소식탭 검수

### DIFF
--- a/actions/news.ts
+++ b/actions/news.ts
@@ -2,8 +2,8 @@
 
 import { revalidateTag } from 'next/cache';
 
-import { postNews } from '@/apis/v1/news';
-import { deleteNews, patchNews } from '@/apis/v1/news/[id]';
+import { postNews } from '@/apis/v2/news';
+import { deleteNews, patchNews } from '@/apis/v2/news/[id]';
 import { FETCH_TAG_NEWS } from '@/constants/network';
 import { news } from '@/constants/segmentNode';
 import { redirectKo } from '@/i18n/routing';

--- a/actions/notice.ts
+++ b/actions/notice.ts
@@ -2,8 +2,8 @@
 
 import { revalidateTag } from 'next/cache';
 
-import { batchDeleteNotice, batchUnpinNotice, postNotice } from '@/apis/v1/notice';
-import { deleteNotice, patchNotice } from '@/apis/v1/notice/[id]';
+import { batchDeleteNotice, batchUnpinNotice, postNotice } from '@/apis/v2/notice';
+import { deleteNotice, patchNotice } from '@/apis/v2/notice/[id]';
 import { FETCH_TAG_NOTICE } from '@/constants/network';
 import { notice } from '@/constants/segmentNode';
 import { redirectKo } from '@/i18n/routing';

--- a/actions/seminar.ts
+++ b/actions/seminar.ts
@@ -2,8 +2,8 @@
 
 import { revalidateTag } from 'next/cache';
 
-import { postSeminar } from '@/apis/v1/seminar';
-import { deleteSeminar, patchSeminar } from '@/apis/v1/seminar/[id]';
+import { postSeminar } from '@/apis/v2/seminar';
+import { deleteSeminar, patchSeminar } from '@/apis/v2/seminar/[id]';
 import { FETCH_TAG_SEMINAR } from '@/constants/network';
 import { seminar } from '@/constants/segmentNode';
 import { redirectKo } from '@/i18n/routing';

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -54,8 +54,11 @@ const _fetch = async (url: string, method: string, init?: CredentialRequestInit)
 
   const resp = await fetch(url, { ...init, method, headers });
 
-  // server action 에러 처리를 위해 status code만 깔끔하게 담음
-  if (!resp.ok) throw new Error(resp.status.toString());
+  if (!resp.ok) {
+    console.error(`${method} ${url} failed: ${resp.status}`);
+    // server action 에러 처리를 위해 status code만 깔끔하게 담음
+    throw new Error(resp.status.toString());
+  }
 
   return resp;
 };

--- a/apis/v2/about/index.ts
+++ b/apis/v2/about/index.ts
@@ -1,9 +1,9 @@
 import { MainResponse } from '@/apis/types/main';
 import { FETCH_TAG_NEWS, FETCH_TAG_NOTICE } from '@/constants/network';
 
-import { getRequest } from '..';
+import { getRequest } from '../..';
 
 export const getMain = () =>
-  getRequest<MainResponse>('/v1', undefined, {
+  getRequest<MainResponse>('/v2', undefined, {
     next: { tags: [FETCH_TAG_NEWS, FETCH_TAG_NOTICE] },
   });

--- a/apis/v2/index.ts
+++ b/apis/v2/index.ts
@@ -1,7 +1,6 @@
+import { getRequest } from '@/apis';
 import { MainResponse } from '@/apis/types/main';
 import { FETCH_TAG_NEWS, FETCH_TAG_NOTICE } from '@/constants/network';
-
-import { getRequest } from '../..';
 
 export const getMain = () =>
   getRequest<MainResponse>('/v2', undefined, {

--- a/apis/v2/news/[id].ts
+++ b/apis/v2/news/[id].ts
@@ -4,13 +4,13 @@ import { PostSearchQueryParams } from '@/apis/types/post';
 import { FETCH_TAG_NEWS } from '@/constants/network';
 
 export const getNewsDetail = (id: number, params?: PostSearchQueryParams) =>
-  getRequest(`/v1/news/${id}`, params, {
+  getRequest(`/v2/news/${id}`, params, {
     next: { tags: [FETCH_TAG_NEWS] },
     jsessionID: true,
   }) as Promise<News>;
 
-export const deleteNews = (id: number) => deleteRequest(`/v1/news/${id}`, { jsessionID: true });
+export const deleteNews = (id: number) => deleteRequest(`/v2/news/${id}`, { jsessionID: true });
 
 export const patchNews = async (id: number, formData: FormData) => {
-  await patchRequest(`/v1/news/${id}`, { body: formData, jsessionID: true });
+  await patchRequest(`/v2/news/${id}`, { body: formData, jsessionID: true });
 };

--- a/apis/v2/news/index.ts
+++ b/apis/v2/news/index.ts
@@ -4,11 +4,11 @@ import { PostSearchQueryParams } from '@/apis/types/post';
 import { FETCH_TAG_NEWS } from '@/constants/network';
 
 export const getNewsPosts = (params: PostSearchQueryParams) =>
-  getRequest('/v1/news', params, {
+  getRequest('/v2/news', params, {
     next: { tags: [FETCH_TAG_NEWS] },
     jsessionID: true,
   }) as Promise<NewsPreviewList>;
 
 export const postNews = async (formData: FormData) => {
-  return postRequest('/v1/news', { body: formData, jsessionID: true }) as Promise<{ id: number }>;
+  return postRequest('/v2/news', { body: formData, jsessionID: true }) as Promise<{ id: number }>;
 };

--- a/apis/v2/news/totalSearch.ts
+++ b/apis/v2/news/totalSearch.ts
@@ -3,6 +3,6 @@ import { NewsSearchResult, SearchParam } from '@/apis/types/search';
 import { FETCH_TAG_NEWS } from '@/constants/network';
 
 export const searchNews = (params: SearchParam) =>
-  getRequest('/v1/news/totalSearch', params, {
+  getRequest('/v2/news/totalSearch', params, {
     next: { tags: [FETCH_TAG_NEWS] },
   }) as Promise<NewsSearchResult>;

--- a/apis/v2/notice/[id].ts
+++ b/apis/v2/notice/[id].ts
@@ -4,12 +4,12 @@ import { PostSearchQueryParams } from '@/apis/types/post';
 import { FETCH_TAG_NOTICE } from '@/constants/network';
 
 export const getNoticePostDetail = (id: number, params: PostSearchQueryParams) =>
-  getRequest(`/v1/notice/${id}`, params, {
+  getRequest(`/v2/notice/${id}`, params, {
     next: { tags: [FETCH_TAG_NOTICE] },
     jsessionID: true,
   }) as Promise<Notice>;
 
 export const patchNotice = (id: number, formData: FormData) =>
-  patchRequest(`/v1/notice/${id}`, { body: formData, jsessionID: true });
+  patchRequest(`/v2/notice/${id}`, { body: formData, jsessionID: true });
 
-export const deleteNotice = (id: number) => deleteRequest(`/v1/notice/${id}`, { jsessionID: true });
+export const deleteNotice = (id: number) => deleteRequest(`/v2/notice/${id}`, { jsessionID: true });

--- a/apis/v2/notice/index.ts
+++ b/apis/v2/notice/index.ts
@@ -4,19 +4,19 @@ import { PostSearchQueryParams } from '@/apis/types/post';
 import { FETCH_TAG_NOTICE } from '@/constants/network';
 
 export const getNoticePosts = (params: PostSearchQueryParams) =>
-  getRequest('/v1/notice', params, {
+  getRequest('/v2/notice', params, {
     next: { tags: [FETCH_TAG_NOTICE] },
     jsessionID: true,
   }) as Promise<NoticePreviewList>;
 
 export const postNotice = async (formData: FormData) => {
-  return postRequest('/v1/notice', { body: formData, jsessionID: true }) as Promise<{
+  return postRequest('/v2/notice', { body: formData, jsessionID: true }) as Promise<{
     id: number;
   }>;
 };
 
 export const batchDeleteNotice = async (ids: Set<number>) => {
-  await deleteRequest('/v1/notice', {
+  await deleteRequest('/v2/notice', {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ idList: Array.from(ids) }),
     jsessionID: true,
@@ -24,7 +24,7 @@ export const batchDeleteNotice = async (ids: Set<number>) => {
 };
 
 export const batchUnpinNotice = async (ids: Set<number>) => {
-  await patchRequest('/v1/notice', {
+  await patchRequest('/v2/notice', {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ idList: Array.from(ids) }),
     jsessionID: true,

--- a/apis/v2/notice/totalSearch.ts
+++ b/apis/v2/notice/totalSearch.ts
@@ -3,6 +3,6 @@ import { NoticeSearchResult, SearchParam } from '@/apis/types/search';
 import { FETCH_TAG_NOTICE } from '@/constants/network';
 
 export const searchNotice = (params: SearchParam) =>
-  getRequest('/v1/notice/totalSearch', params, {
+  getRequest('/v2/notice/totalSearch', params, {
     next: { tags: [FETCH_TAG_NOTICE] },
   }) as Promise<NoticeSearchResult>;

--- a/apis/v2/seminar/[id].ts
+++ b/apis/v2/seminar/[id].ts
@@ -4,15 +4,15 @@ import { Seminar } from '@/apis/types/seminar';
 import { FETCH_TAG_SEMINAR } from '@/constants/network';
 
 export const getSeminarPost = async (id: number, params: PostSearchQueryParams) => {
-  return getRequest(`/v1/seminar/${id}`, params, {
+  return getRequest(`/v2/seminar/${id}`, params, {
     next: { tags: [FETCH_TAG_SEMINAR] },
     jsessionID: true,
   }) as Promise<Seminar>;
 };
 
 export const patchSeminar = async (id: number, formData: FormData) => {
-  await patchRequest(`/v1/seminar/${id}`, { body: formData, jsessionID: true });
+  await patchRequest(`/v2/seminar/${id}`, { body: formData, jsessionID: true });
 };
 
 export const deleteSeminar = async (id: number) =>
-  deleteRequest(`/v1/seminar/${id}`, { jsessionID: true });
+  deleteRequest(`/v2/seminar/${id}`, { jsessionID: true });

--- a/apis/v2/seminar/index.ts
+++ b/apis/v2/seminar/index.ts
@@ -4,14 +4,14 @@ import { SeminarPreviewList } from '@/apis/types/seminar';
 import { FETCH_TAG_SEMINAR } from '@/constants/network';
 
 export const getSeminarPosts = async (params: PostSearchQueryParams) => {
-  return getRequest('/v1/seminar', params, {
+  return getRequest('/v2/seminar', params, {
     next: { tags: [FETCH_TAG_SEMINAR] },
     jsessionID: true,
   }) as Promise<SeminarPreviewList>;
 };
 
 export const postSeminar = async (formData: FormData) => {
-  return postRequest('/v1/seminar', { body: formData, jsessionID: true }) as Promise<{
+  return postRequest('/v2/seminar', { body: formData, jsessionID: true }) as Promise<{
     id: number;
   }>;
 };

--- a/app/[locale]/community/news/[id]/edit/page.tsx
+++ b/app/[locale]/community/news/[id]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { getNewsDetail } from '@/apis/v1/news/[id]';
+import { getNewsDetail } from '@/apis/v2/news/[id]';
 
 import EditNewsPageContent from './EditNewsPageContent';
 

--- a/app/[locale]/community/news/[id]/page.tsx
+++ b/app/[locale]/community/news/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 
 import { PostSearchQueryParams } from '@/apis/types/post';
-import { getNewsDetail } from '@/apis/v1/news/[id]';
+import { getNewsDetail } from '@/apis/v2/news/[id]';
 import PostFallback from '@/app/[locale]/community/components/PostFallback';
 import InvalidIDFallback from '@/components/common/InvalidIDFallback';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';

--- a/app/[locale]/community/news/components/NewsEditor.tsx
+++ b/app/[locale]/community/news/components/NewsEditor.tsx
@@ -93,8 +93,20 @@ export default function NewsEditor({ defaultValues, onCancel, onSubmit, onDelete
                 }
               }}
             />
-            <Form.Checkbox label="메인-중요 안내에 표시" name="isImportant" />
-            <Form.Checkbox label="메인-슬라이드쇼에 표시" name="isSlide" />
+            <Form.Checkbox
+              label="메인-중요 안내에 표시"
+              name="isImportant"
+              onChange={(isImportant) => {
+                if (isImportant) setValue('isPrivate', false);
+              }}
+            />
+            <Form.Checkbox
+              label="메인-슬라이드쇼에 표시"
+              name="isSlide"
+              onChange={(isImportant) => {
+                if (isImportant) setValue('isPrivate', false);
+              }}
+            />
             <p className="text-xs font-light tracking-wide text-neutral-700">
               * ‘슬라이드쇼에 표시’ 글은 대표이미지가 첨부되어있는지 확인 바랍니다.
             </p>

--- a/app/[locale]/community/news/page.tsx
+++ b/app/[locale]/community/news/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
 import { PostSearchQueryParams } from '@/apis/types/post';
-import { getNewsPosts } from '@/apis/v1/news';
+import { getNewsPosts } from '@/apis/v2/news';
 import NewsPageContent from '@/app/[locale]/community/news/components/NewsPageContent';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { news } from '@/constants/segmentNode';

--- a/app/[locale]/community/notice/[id]/edit/page.tsx
+++ b/app/[locale]/community/notice/[id]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { getNoticePostDetail } from '@/apis/v1/notice/[id]';
+import { getNoticePostDetail } from '@/apis/v2/notice/[id]';
 import EditNoticePageContent from '@/app/[locale]/community/notice/[id]/edit/EditNoticePageContent';
 
 interface EditNoticePageProps {

--- a/app/[locale]/community/notice/[id]/page.tsx
+++ b/app/[locale]/community/notice/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 
 import { PostSearchQueryParams } from '@/apis/types/post';
-import { getNoticePostDetail } from '@/apis/v1/notice/[id]';
+import { getNoticePostDetail } from '@/apis/v2/notice/[id]';
 import PostFallback from '@/app/[locale]/community/components/PostFallback';
 import InvalidIDFallback from '@/components/common/InvalidIDFallback';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';

--- a/app/[locale]/community/notice/components/NoticeEditor.tsx
+++ b/app/[locale]/community/notice/components/NoticeEditor.tsx
@@ -81,8 +81,20 @@ export default function NoticeEditor({ defaultValues, onCancel, onSubmit, onDele
                 }
               }}
             />
-            <Form.Checkbox label="목록 상단에 고정" name="isFixed" />
-            <Form.Checkbox label="메인-중요 안내에 표시" name="isImportant" />
+            <Form.Checkbox
+              label="목록 상단에 고정"
+              name="isPinned"
+              onChange={(isImportant) => {
+                if (isImportant) setValue('isPrivate', false);
+              }}
+            />
+            <Form.Checkbox
+              label="메인-중요 안내에 표시"
+              name="isImportant"
+              onChange={(isImportant) => {
+                if (isImportant) setValue('isPrivate', false);
+              }}
+            />
           </div>
         </Fieldset>
         <Form.Action

--- a/app/[locale]/community/notice/page.tsx
+++ b/app/[locale]/community/notice/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
 import { PostSearchQueryParams } from '@/apis/types/post';
-import { getNoticePosts } from '@/apis/v1/notice';
+import { getNoticePosts } from '@/apis/v2/notice';
 import NoticePageContent from '@/app/[locale]/community/notice/NoticePageContent';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { notice } from '@/constants/segmentNode';

--- a/app/[locale]/community/seminar/[id]/edit/EditSeminarPageContent.tsx
+++ b/app/[locale]/community/seminar/[id]/edit/EditSeminarPageContent.tsx
@@ -90,8 +90,8 @@ export default function EditSeminarPageContent({ id, data }: { id: number; data:
   return (
     <PageLayout title="세미나 편집" titleType="big" titleMargin="mb-[2.25rem]" hideNavbar>
       <SeminarEditor
-        onCancel={onCancel}
-        onSubmit={onSubmit}
+        onCancelAction={onCancel}
+        onSubmitAction={onSubmit}
         onDelete={onDelete}
         defaultValues={defaultValues}
       />

--- a/app/[locale]/community/seminar/[id]/edit/page.tsx
+++ b/app/[locale]/community/seminar/[id]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { getSeminarPost } from '@/apis/v1/seminar/[id]';
+import { getSeminarPost } from '@/apis/v2/seminar/[id]';
 import EditSeminarPageContent from '@/app/[locale]/community/seminar/[id]/edit/EditSeminarPageContent';
 
 interface EditNoticePageProps {

--- a/app/[locale]/community/seminar/[id]/page.tsx
+++ b/app/[locale]/community/seminar/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 
 import { PostSearchQueryParams } from '@/apis/types/post';
-import { getSeminarPost } from '@/apis/v1/seminar/[id]';
+import { getSeminarPost } from '@/apis/v2/seminar/[id]';
 import PostFallback from '@/app/[locale]/community/components/PostFallback';
 import InvalidIDFallback from '@/components/common/InvalidIDFallback';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';

--- a/app/[locale]/community/seminar/components/SeminarEditor.tsx
+++ b/app/[locale]/community/seminar/components/SeminarEditor.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { FormProvider, useForm, useFormContext, useWatch } from 'react-hook-form';
 
 import Fieldset from '@/components/form/Fieldset';
@@ -33,12 +31,17 @@ export interface SeminarFormData {
 
 interface Props {
   defaultValues?: SeminarFormData;
-  onCancel: () => void;
-  onSubmit: (formData: SeminarFormData) => Promise<void>;
+  onCancelAction: () => void;
+  onSubmitAction: (formData: SeminarFormData) => Promise<void>;
   onDelete?: () => Promise<void>;
 }
 
-export default function SeminarEditor({ defaultValues, onCancel, onSubmit, onDelete }: Props) {
+export default function SeminarEditor({
+  defaultValues,
+  onCancelAction,
+  onSubmitAction,
+  onDelete,
+}: Props) {
   const formMethods = useForm<SeminarFormData>({
     defaultValues: defaultValues ?? {
       title: '',
@@ -154,7 +157,11 @@ export default function SeminarEditor({ defaultValues, onCancel, onSubmit, onDel
           </div>
         </Fieldset>
 
-        <Form.Action onCancel={onCancel} onSubmit={handleSubmit(onSubmit)} onDelete={onDelete} />
+        <Form.Action
+          onCancel={onCancelAction}
+          onSubmit={handleSubmit(onSubmitAction)}
+          onDelete={onDelete}
+        />
       </Form>
     </FormProvider>
   );

--- a/app/[locale]/community/seminar/create/page.tsx
+++ b/app/[locale]/community/seminar/create/page.tsx
@@ -34,7 +34,7 @@ export default function SeminarCreatePage() {
 
   return (
     <PageLayout title="세미나 작성" titleType="big" titleMargin="mb-[2.25rem]" hideNavbar>
-      <SeminarEditor onCancel={onCancel} onSubmit={onSubmit} />
+      <SeminarEditor onCancelAction={onCancel} onSubmitAction={onSubmit} />
     </PageLayout>
   );
 }

--- a/app/[locale]/community/seminar/page.tsx
+++ b/app/[locale]/community/seminar/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
 import { PostSearchQueryParams } from '@/apis/types/post';
-import { getSeminarPosts } from '@/apis/v1/seminar';
+import { getSeminarPosts } from '@/apis/v2/seminar';
 import LoginVisible from '@/components/common/LoginVisible';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { seminar } from '@/constants/segmentNode';

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 
 import { MainImportant } from '@/apis/types/main';
-import { getMain } from '@/apis/v1';
+import { getMain } from '@/apis/v2/about';
 import GraphicSection from '@/app/[locale]/components/GraphicSection';
 import NewsSection from '@/app/[locale]/components/NewsSection';
 import NoticeSection from '@/app/[locale]/components/NoticeSection';

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 
 import { MainImportant } from '@/apis/types/main';
-import { getMain } from '@/apis/v2/about';
+import { getMain } from '@/apis/v2';
 import GraphicSection from '@/app/[locale]/components/GraphicSection';
 import NewsSection from '@/app/[locale]/components/NewsSection';
 import NoticeSection from '@/app/[locale]/components/NoticeSection';

--- a/app/[locale]/search/fetchContent.ts
+++ b/app/[locale]/search/fetchContent.ts
@@ -14,7 +14,7 @@ import { searchAdmissions } from '@/apis/v1/admissions/search/top';
 import { searchMember } from '@/apis/v1/member/search/top';
 import { searchNews } from '@/apis/v2/news/totalSearch';
 import { searchNotice } from '@/apis/v2/notice/totalSearch';
-import { getSeminarPosts } from '@/apis/v1/seminar';
+import { getSeminarPosts } from '@/apis/v2/seminar';
 import { searchResearch } from '@/apis/v2/research/search/top';
 
 import { TreeNode } from './helper/SearchSubNavbar';

--- a/app/[locale]/search/fetchContent.ts
+++ b/app/[locale]/search/fetchContent.ts
@@ -13,7 +13,7 @@ import { searchAcademics } from '@/apis/v1/academics/search/top';
 import { searchAdmissions } from '@/apis/v1/admissions/search/top';
 import { searchMember } from '@/apis/v1/member/search/top';
 import { searchNews } from '@/apis/v1/news/totalSearch';
-import { searchNotice } from '@/apis/v1/notice/totalSearch';
+import { searchNotice } from '@/apis/v2/notice/totalSearch';
 import { getSeminarPosts } from '@/apis/v1/seminar';
 import { searchResearch } from '@/apis/v2/research/search/top';
 

--- a/app/[locale]/search/fetchContent.ts
+++ b/app/[locale]/search/fetchContent.ts
@@ -12,7 +12,7 @@ import { searchAbout } from '@/apis/v1/about/search/top';
 import { searchAcademics } from '@/apis/v1/academics/search/top';
 import { searchAdmissions } from '@/apis/v1/admissions/search/top';
 import { searchMember } from '@/apis/v1/member/search/top';
-import { searchNews } from '@/apis/v1/news/totalSearch';
+import { searchNews } from '@/apis/v2/news/totalSearch';
 import { searchNotice } from '@/apis/v2/notice/totalSearch';
 import { getSeminarPosts } from '@/apis/v1/seminar';
 import { searchResearch } from '@/apis/v2/research/search/top';

--- a/components/layout/pageLayout/paddings.ts
+++ b/components/layout/pageLayout/paddings.ts
@@ -1,4 +1,4 @@
 export const PAGE_PADDING_LEFT_PX = 100;
 export const PAGE_PADDING_RIGHT_PX = 360;
 export const PAGE_PADDING_TOP_PX = 44;
-export const PAGE_PADDING_BOTTOM_TAILWIND = '150px';
+export const PAGE_PADDING_BOTTOM_TAILWIND = 'pb-[150px]';


### PR DESCRIPTION
## 작업 요약

- 소식탭 api v1 -> v2 반영
- fetch 실패시 로깅 처리
- 게시글 뷰어 하단 패딩이 없는 문제 수정(tailwind 상수값 오타 수정)
- 고정글 혹은 메인노출글 체크시 비밀글 체크가 풀리지 않는 문제 수정

## 상세 내용

.

## 테스트 방법

- 소식탭 게시물 상세 페이지에서 푸터 상단 패딩이 잘 들어갔는지 확인
- 편집 페이지에서 체크박스들간에 필요한 싱크가 잘 맞는지 확인

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
