### PR TITLE
✨ 입학탭 편집 기능

### DIFF
--- a/actions/admissions.ts
+++ b/actions/admissions.ts
@@ -1,0 +1,22 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+import { putAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
+import { FETCH_TAG_REGULAR_ADMISSON } from '@/constants/network';
+import { undergraduateRegularAdmission } from '@/constants/segmentNode';
+import { redirectKo } from '@/i18n/routing';
+import { WithLanguage } from '@/types/language';
+import { getPath } from '@/utils/page';
+
+import { withErrorHandler } from './errorHandler';
+
+const undergraduateRegularAdmissionPath = getPath(undergraduateRegularAdmission);
+
+export const putUndergraduateRegularAdmissionsAction = withErrorHandler(
+  async (data: WithLanguage<string>) => {
+    await putAdmissions('undergraduate', 'regular-admission', data);
+    revalidateTag(FETCH_TAG_REGULAR_ADMISSON);
+    redirectKo(undergraduateRegularAdmissionPath);
+  },
+);

--- a/actions/admissions.ts
+++ b/actions/admissions.ts
@@ -3,20 +3,100 @@
 import { revalidateTag } from 'next/cache';
 
 import { putAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
-import { FETCH_TAG_REGULAR_ADMISSON } from '@/constants/network';
-import { undergraduateRegularAdmission } from '@/constants/segmentNode';
+import {
+  FETCH_TAG_EARLY_ADMISSION,
+  FETCH_TAG_EXCHANGE,
+  FETCH_TAG_GRADUATE_ADMISSION,
+  FETCH_TAG_INTERNATIONAL_GRADUATE,
+  FETCH_TAG_INTERNATIONAL_SCHOLARSHIPS,
+  FETCH_TAG_INTERNATIONAL_UNDERGRADUATE,
+  FETCH_TAG_REGULAR_ADMISSION,
+} from '@/constants/network';
+import {
+  exchangeVisitingProgram,
+  graduateRegularAdmission,
+  internationalGraduateAdmission,
+  internationalScholarships,
+  internationalUndergraduateAdmission,
+  undergraduateEarlyAdmission,
+  undergraduateRegularAdmission,
+} from '@/constants/segmentNode';
 import { redirectKo } from '@/i18n/routing';
 import { WithLanguage } from '@/types/language';
 import { getPath } from '@/utils/page';
 
 import { withErrorHandler } from './errorHandler';
 
+/** 학부 입학 */
+
 const undergraduateRegularAdmissionPath = getPath(undergraduateRegularAdmission);
 
 export const putUndergraduateRegularAdmissionsAction = withErrorHandler(
   async (data: WithLanguage<string>) => {
     await putAdmissions('undergraduate', 'regular-admission', data);
-    revalidateTag(FETCH_TAG_REGULAR_ADMISSON);
+    revalidateTag(FETCH_TAG_REGULAR_ADMISSION);
     redirectKo(undergraduateRegularAdmissionPath);
+  },
+);
+
+const undergraduateEarlyAdmissionPath = getPath(undergraduateEarlyAdmission);
+
+export const putUndergraduateEarlyAdmissionsAction = withErrorHandler(
+  async (data: WithLanguage<string>) => {
+    await putAdmissions('undergraduate', 'early-admission', data);
+    revalidateTag(FETCH_TAG_EARLY_ADMISSION);
+    redirectKo(undergraduateEarlyAdmissionPath);
+  },
+);
+
+/** 대학원 입학 */
+
+const graduateAdmissionPath = getPath(graduateRegularAdmission);
+
+export const putGraduateAdmissionsAction = withErrorHandler(async (data: WithLanguage<string>) => {
+  await putAdmissions('graduate', 'regular-admission', data);
+  revalidateTag(FETCH_TAG_GRADUATE_ADMISSION);
+  redirectKo(graduateAdmissionPath);
+});
+
+/** International */
+
+const internationalUndergraduatePath = getPath(internationalUndergraduateAdmission);
+
+export const putInternationalUndergraduateAction = withErrorHandler(
+  async (data: WithLanguage<string>) => {
+    await putAdmissions('international', 'undergraduate', data);
+    revalidateTag(FETCH_TAG_INTERNATIONAL_UNDERGRADUATE);
+    redirectKo(internationalUndergraduatePath);
+  },
+);
+
+const internationalGraduatePath = getPath(internationalGraduateAdmission);
+
+export const putInternationalGraduateAction = withErrorHandler(
+  async (data: WithLanguage<string>) => {
+    await putAdmissions('international', 'graduate', data);
+    revalidateTag(FETCH_TAG_INTERNATIONAL_GRADUATE);
+    redirectKo(internationalGraduatePath);
+  },
+);
+
+const internationalExchangePath = getPath(exchangeVisitingProgram);
+
+export const putInternationalExchangeAction = withErrorHandler(
+  async (data: WithLanguage<string>) => {
+    await putAdmissions('international', 'exchange-visiting', data);
+    revalidateTag(FETCH_TAG_EXCHANGE);
+    redirectKo(internationalExchangePath);
+  },
+);
+
+const internationalScholarshipsPath = getPath(internationalScholarships);
+
+export const putInternationalScholarshipsAction = withErrorHandler(
+  async (data: WithLanguage<string>) => {
+    await putAdmissions('international', 'scholarships', data);
+    revalidateTag(FETCH_TAG_INTERNATIONAL_SCHOLARSHIPS);
+    redirectKo(internationalScholarshipsPath);
   },
 );

--- a/apis/v2/admissions/[mainType]/[postType].ts
+++ b/apis/v2/admissions/[mainType]/[postType].ts
@@ -1,0 +1,27 @@
+import { getRequest, putRequest } from '@/apis';
+import { WithLanguage } from '@/types/language';
+
+type MainType = 'undergraduate' | 'graduate' | 'international';
+type PostType =
+  | 'early-admission'
+  | 'regular-admission'
+  | 'exchange-visiting'
+  | 'graduate'
+  | 'scholarships'
+  | 'undergraduate';
+
+export const getAdmissions = (mainType: MainType, postType: PostType, fetchTag: string) =>
+  getRequest(`/v2/admissions/${mainType}/${postType}`, undefined, {
+    next: { tags: [fetchTag] },
+  }) as Promise<WithLanguage<{ description: string }>>;
+
+export const putAdmissions = (
+  mainType: MainType,
+  postType: PostType,
+  description: WithLanguage<string>,
+) =>
+  putRequest(`/v2/admissions/${mainType}/${postType}`, {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(description),
+    jsessionID: true,
+  });

--- a/apis/v2/admissions/graduate/regular-admission.ts
+++ b/apis/v2/admissions/graduate/regular-admission.ts
@@ -1,7 +1,0 @@
-import { getRequest } from '@/apis';
-import { WithLanguage } from '@/types/language';
-
-export const getGraduateRegularAdmission = () =>
-  getRequest('/v2/admissions/graduate/regular-admission') as Promise<
-    WithLanguage<{ description: string }>
-  >;

--- a/apis/v2/admissions/international/exchange-visiting.ts
+++ b/apis/v2/admissions/international/exchange-visiting.ts
@@ -1,7 +1,0 @@
-import { getRequest } from '@/apis';
-import { WithLanguage } from '@/types/language';
-
-export const getInternationalExchangeVisiting = () =>
-  getRequest('/v2/admissions/international/exchange-visiting') as Promise<
-    WithLanguage<{ description: string }>
-  >;

--- a/apis/v2/admissions/international/graduate.ts
+++ b/apis/v2/admissions/international/graduate.ts
@@ -1,7 +1,0 @@
-import { getRequest } from '@/apis';
-import { WithLanguage } from '@/types/language';
-
-export const getInternationalgraduate = () =>
-  getRequest('/v2/admissions/international/graduate') as Promise<
-    WithLanguage<{ description: string }>
-  >;

--- a/apis/v2/admissions/international/scholarships.ts
+++ b/apis/v2/admissions/international/scholarships.ts
@@ -1,7 +1,0 @@
-import { getRequest } from '@/apis';
-import { WithLanguage } from '@/types/language';
-
-export const getInternationalScholarships = () =>
-  getRequest('/v2/admissions/international/scholarships') as Promise<
-    WithLanguage<{ description: string }>
-  >;

--- a/apis/v2/admissions/international/undergraduate.ts
+++ b/apis/v2/admissions/international/undergraduate.ts
@@ -1,7 +1,0 @@
-import { getRequest } from '@/apis';
-import { WithLanguage } from '@/types/language';
-
-export const getInternationalUndergraduate = () =>
-  getRequest('/v2/admissions/international/undergraduate') as Promise<
-    WithLanguage<{ description: string }>
-  >;

--- a/apis/v2/admissions/undergraduate/early-admission.ts
+++ b/apis/v2/admissions/undergraduate/early-admission.ts
@@ -1,7 +1,0 @@
-import { getRequest } from '@/apis';
-import { WithLanguage } from '@/types/language';
-
-export const getUndergraduateEarlyAdmission = () =>
-  getRequest('/v2/admissions/undergraduate/early-admission') as Promise<
-    WithLanguage<{ description: string }>
-  >;

--- a/apis/v2/admissions/undergraduate/regular-admission.ts
+++ b/apis/v2/admissions/undergraduate/regular-admission.ts
@@ -1,7 +1,0 @@
-import { getRequest } from '@/apis';
-import { WithLanguage } from '@/types/language';
-
-export const getUndergraduateRegularAdmission = () =>
-  getRequest('/v2/admissions/undergraduate/regular-admission') as Promise<
-    WithLanguage<{ description: string }>
-  >;

--- a/app/[locale]/admissions/components/AdmissionsEditor.tsx
+++ b/app/[locale]/admissions/components/AdmissionsEditor.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import Fieldset from '@/components/form/Fieldset';
+import Form from '@/components/form/Form';
+import LanguagePicker from '@/components/form/LanguagePicker';
+import { useRouter } from '@/i18n/routing';
+import { Language } from '@/types/language';
+import { CustomError, handleServerResponse } from '@/utils/serverActionError';
+
+export type AdmissionsFormData = {
+  ko: string;
+  en: string;
+};
+
+type Props = {
+  defaultValues: AdmissionsFormData;
+  cancelPath: string;
+  onSubmit: (data: AdmissionsFormData) => Promise<void | CustomError>;
+};
+
+export default function AdmissionsEditor({
+  defaultValues,
+  cancelPath,
+  onSubmit: _onSubmit,
+}: Props) {
+  const formMethods = useForm<AdmissionsFormData>({ defaultValues });
+  const { handleSubmit } = formMethods;
+  const router = useRouter();
+  const [language, setLanguage] = useState<Language>('ko');
+
+  const onSubmit = async (formData: AdmissionsFormData) => {
+    const resp = _onSubmit(formData);
+    handleServerResponse(resp, { successMessage: '입학 본문을 수정했습니다.' });
+  };
+
+  const onCancel = () => router.push(cancelPath);
+
+  return (
+    <FormProvider {...formMethods}>
+      <Form>
+        <LanguagePicker selected={language} onChange={setLanguage} />
+        {language === 'ko' && <Editor language="ko" />}
+        {language === 'en' && <Editor language="en" />}
+        <Form.Action onCancel={onCancel} onSubmit={handleSubmit(onSubmit)} />
+      </Form>
+    </FormProvider>
+  );
+}
+
+const Editor = ({ language }: { language: Language }) => {
+  return (
+    <Fieldset.HTML>
+      <Form.HTML name={language} options={{ required: true }} />
+    </Fieldset.HTML>
+  );
+};

--- a/app/[locale]/admissions/components/AdmissionsPageContent.tsx
+++ b/app/[locale]/admissions/components/AdmissionsPageContent.tsx
@@ -1,0 +1,26 @@
+import { BlackButton } from '@/components/common/Buttons';
+import LoginVisible from '@/components/common/LoginVisible';
+import HTMLViewer from '@/components/form/html/HTMLViewer';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { Link } from '@/i18n/routing';
+
+export default function AdmissionsPageContent({
+  description,
+  pathname,
+}: {
+  description: string;
+  pathname: string;
+}) {
+  return (
+    <PageLayout titleType="big">
+      <LoginVisible staff>
+        <div className="text-right">
+          <Link href={`${pathname}/edit`}>
+            <BlackButton title="편집" />
+          </Link>
+        </div>
+      </LoginVisible>
+      <HTMLViewer htmlContent={description} />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/admissions/components/AdmissionsPageContent.tsx
+++ b/app/[locale]/admissions/components/AdmissionsPageContent.tsx
@@ -7,20 +7,24 @@ import { Link } from '@/i18n/routing';
 export default function AdmissionsPageContent({
   description,
   pathname,
+  removeBottomPadding,
+  htmlWrapperClassName,
 }: {
   description: string;
   pathname: string;
+  removeBottomPadding?: boolean;
+  htmlWrapperClassName?: string;
 }) {
   return (
-    <PageLayout titleType="big">
+    <PageLayout titleType="big" removeBottomPadding={removeBottomPadding}>
       <LoginVisible staff>
-        <div className="text-right">
+        <div className="pb-8 text-right">
           <Link href={`${pathname}/edit`}>
             <BlackButton title="편집" />
           </Link>
         </div>
       </LoginVisible>
-      <HTMLViewer htmlContent={description} />
+      <HTMLViewer htmlContent={description} wrapperClassName={htmlWrapperClassName} />
     </PageLayout>
   );
 }

--- a/app/[locale]/admissions/graduate/regular-admission/edit/page.tsx
+++ b/app/[locale]/admissions/graduate/regular-admission/edit/page.tsx
@@ -1,0 +1,24 @@
+import { putGraduateAdmissionsAction } from '@/actions/admissions';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_GRADUATE_ADMISSION } from '@/constants/network';
+import { graduateRegularAdmission } from '@/constants/segmentNode';
+import { getPath } from '@/utils/page';
+
+import AdmissionsEditor from '../../../components/AdmissionsEditor';
+
+const path = getPath(graduateRegularAdmission);
+
+export default async function GraduateRegularAdmissionEditPage() {
+  const data = await getAdmissions('graduate', 'regular-admission', FETCH_TAG_GRADUATE_ADMISSION);
+
+  return (
+    <PageLayout title="대학원 전기/후기 모집 수정" titleType="big">
+      <AdmissionsEditor
+        defaultValues={{ ko: data.ko.description, en: data.en.description }}
+        cancelPath={path}
+        onSubmit={putGraduateAdmissionsAction}
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/admissions/graduate/regular-admission/page.tsx
+++ b/app/[locale]/admissions/graduate/regular-admission/page.tsx
@@ -1,27 +1,27 @@
 import { Metadata } from 'next';
 
-import { getGraduateRegularAdmission } from '@/apis/v2/admissions/graduate/regular-admission';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import { AdmissionPageProps } from '@/app/[locale]/admissions/type';
-import HTMLViewer from '@/components/form/html/HTMLViewer';
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { graduateAdmission } from '@/constants/segmentNode';
+import { FETCH_TAG_GRADUATE_ADMISSION } from '@/constants/network';
+import { graduateRegularAdmission } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
+
+import AdmissionsPageContent from '../../components/AdmissionsPageContent';
 
 export async function generateMetadata(props: AdmissionPageProps): Promise<Metadata> {
   const params = await props.params;
 
   const { locale } = params;
 
-  return await getMetadata({ locale, node: graduateAdmission });
+  return await getMetadata({ locale, node: graduateRegularAdmission });
 }
+
+const path = getPath(graduateRegularAdmission);
 
 export default async function GraduateRegularAdmission({ params }: AdmissionPageProps) {
   const locale = (await params).locale;
-  const data = await getGraduateRegularAdmission();
+  const data = await getAdmissions('graduate', 'regular-admission', FETCH_TAG_GRADUATE_ADMISSION);
 
-  return (
-    <PageLayout titleType="big">
-      <HTMLViewer htmlContent={data[locale].description} />
-    </PageLayout>
-  );
+  return <AdmissionsPageContent pathname={path} description={data[locale].description} />;
 }

--- a/app/[locale]/admissions/international/exchange/edit/page.tsx
+++ b/app/[locale]/admissions/international/exchange/edit/page.tsx
@@ -1,0 +1,24 @@
+import { putInternationalExchangeAction } from '@/actions/admissions';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_EXCHANGE } from '@/constants/network';
+import { exchangeVisitingProgram } from '@/constants/segmentNode';
+import { getPath } from '@/utils/page';
+
+import AdmissionsEditor from '../../../components/AdmissionsEditor';
+
+const path = getPath(exchangeVisitingProgram);
+
+export default async function InternationalExchangeEditPage() {
+  const data = await getAdmissions('international', 'exchange-visiting', FETCH_TAG_EXCHANGE);
+
+  return (
+    <PageLayout title="International Exchange/Visiting Program 편집" titleType="big">
+      <AdmissionsEditor
+        defaultValues={{ ko: data.ko.description, en: data.en.description }}
+        cancelPath={path}
+        onSubmit={putInternationalExchangeAction}
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/admissions/international/exchange/page.tsx
+++ b/app/[locale]/admissions/international/exchange/page.tsx
@@ -1,15 +1,13 @@
-import { Metadata } from 'next';
-
-import { getInternationalExchangeVisiting } from '@/apis/v2/admissions/international/exchange-visiting';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import { AdmissionPageProps } from '@/app/[locale]/admissions/type';
-import HTMLViewer from '@/components/form/html/HTMLViewer';
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_EXCHANGE } from '@/constants/network';
 import { exchangeVisitingProgram } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
 
-export async function generateMetadata(props: {
-  params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
+import AdmissionsPageContent from '../../components/AdmissionsPageContent';
+
+export async function generateMetadata(props: { params: Promise<{ locale: string }> }) {
   const params = await props.params;
 
   const { locale } = params;
@@ -23,13 +21,18 @@ export async function generateMetadata(props: {
   });
 }
 
+const path = getPath(exchangeVisitingProgram);
+
 export default async function InternationalExchangePage({ params }: AdmissionPageProps) {
   const locale = (await params).locale;
-  const data = await getInternationalExchangeVisiting();
+  const data = await getAdmissions('international', 'exchange-visiting', FETCH_TAG_EXCHANGE);
 
   return (
-    <PageLayout titleType="big" removeBottomPadding>
-      <HTMLViewer htmlContent={data[locale].description} wrapperClassName="pb-16 sm:pb-[220px]" />
-    </PageLayout>
+    <AdmissionsPageContent
+      pathname={path}
+      description={data[locale].description}
+      removeBottomPadding
+      htmlWrapperClassName="pb-16 sm:pb-[220px]"
+    />
   );
 }

--- a/app/[locale]/admissions/international/graduate/edit/page.tsx
+++ b/app/[locale]/admissions/international/graduate/edit/page.tsx
@@ -1,0 +1,24 @@
+import { putInternationalGraduateAction } from '@/actions/admissions';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_INTERNATIONAL_GRADUATE } from '@/constants/network';
+import { internationalGraduateAdmission } from '@/constants/segmentNode';
+import { getPath } from '@/utils/page';
+
+import AdmissionsEditor from '../../../components/AdmissionsEditor';
+
+const path = getPath(internationalGraduateAdmission);
+
+export default async function InternationalGraduateAdmissionEditPage() {
+  const data = await getAdmissions('international', 'graduate', FETCH_TAG_INTERNATIONAL_GRADUATE);
+
+  return (
+    <PageLayout title="International Graduate Admission 편집" titleType="big">
+      <AdmissionsEditor
+        defaultValues={{ ko: data.ko.description, en: data.en.description }}
+        cancelPath={path}
+        onSubmit={putInternationalGraduateAction}
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/admissions/international/graduate/page.tsx
+++ b/app/[locale]/admissions/international/graduate/page.tsx
@@ -1,15 +1,13 @@
-import { Metadata } from 'next';
-
-import { getInternationalgraduate } from '@/apis/v2/admissions/international/graduate';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import { AdmissionPageProps } from '@/app/[locale]/admissions/type';
-import HTMLViewer from '@/components/form/html/HTMLViewer';
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_INTERNATIONAL_GRADUATE } from '@/constants/network';
 import { internationalGraduateAdmission } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
 
-export async function generateMetadata(props: {
-  params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
+import AdmissionsPageContent from '../../components/AdmissionsPageContent';
+
+export async function generateMetadata(props: { params: Promise<{ locale: string }> }) {
   const params = await props.params;
 
   const { locale } = params;
@@ -23,13 +21,11 @@ export async function generateMetadata(props: {
   });
 }
 
+const path = getPath(internationalGraduateAdmission);
+
 export default async function InternationalGraduateAdmissionPage({ params }: AdmissionPageProps) {
   const locale = (await params).locale;
-  const data = await getInternationalgraduate();
+  const data = await getAdmissions('international', 'graduate', FETCH_TAG_INTERNATIONAL_GRADUATE);
 
-  return (
-    <PageLayout titleType="big">
-      <HTMLViewer htmlContent={data[locale].description} />
-    </PageLayout>
-  );
+  return <AdmissionsPageContent pathname={path} description={data[locale].description} />;
 }

--- a/app/[locale]/admissions/international/scholarships/edit/page.tsx
+++ b/app/[locale]/admissions/international/scholarships/edit/page.tsx
@@ -1,0 +1,28 @@
+import { putInternationalScholarshipsAction } from '@/actions/admissions';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_INTERNATIONAL_SCHOLARSHIPS } from '@/constants/network';
+import { internationalScholarships } from '@/constants/segmentNode';
+import { getPath } from '@/utils/page';
+
+import AdmissionsEditor from '../../../components/AdmissionsEditor';
+
+const path = getPath(internationalScholarships);
+
+export default async function InternationalScholarshipsEditPage() {
+  const data = await getAdmissions(
+    'international',
+    'scholarships',
+    FETCH_TAG_INTERNATIONAL_SCHOLARSHIPS,
+  );
+
+  return (
+    <PageLayout title="International Scholarships 편집" titleType="big">
+      <AdmissionsEditor
+        defaultValues={{ ko: data.ko.description, en: data.en.description }}
+        cancelPath={path}
+        onSubmit={putInternationalScholarshipsAction}
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/admissions/international/scholarships/page.tsx
+++ b/app/[locale]/admissions/international/scholarships/page.tsx
@@ -1,15 +1,13 @@
-import { Metadata } from 'next';
-
-import { getInternationalScholarships } from '@/apis/v2/admissions/international/scholarships';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import { AdmissionPageProps } from '@/app/[locale]/admissions/type';
-import HTMLViewer from '@/components/form/html/HTMLViewer';
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_INTERNATIONAL_SCHOLARSHIPS } from '@/constants/network';
 import { internationalScholarships } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
 
-export async function generateMetadata(props: {
-  params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
+import AdmissionsPageContent from '../../components/AdmissionsPageContent';
+
+export async function generateMetadata(props: { params: Promise<{ locale: string }> }) {
   const params = await props.params;
 
   const { locale } = params;
@@ -23,13 +21,22 @@ export async function generateMetadata(props: {
   });
 }
 
-export default async function InternationalScholarshipPage({ params }: AdmissionPageProps) {
+const path = getPath(internationalScholarships);
+
+export default async function InternationalScholarshipsPage({ params }: AdmissionPageProps) {
   const locale = (await params).locale;
-  const data = await getInternationalScholarships();
+  const data = await getAdmissions(
+    'international',
+    'scholarships',
+    FETCH_TAG_INTERNATIONAL_SCHOLARSHIPS,
+  );
 
   return (
-    <PageLayout titleType="big" removeBottomPadding>
-      <HTMLViewer htmlContent={data[locale].description} wrapperClassName="pb-16 sm:pb-[220px]" />
-    </PageLayout>
+    <AdmissionsPageContent
+      pathname={path}
+      description={data[locale].description}
+      removeBottomPadding
+      htmlWrapperClassName="pb-16 sm:pb-[220px]"
+    />
   );
 }

--- a/app/[locale]/admissions/international/undergraduate/edit/page.tsx
+++ b/app/[locale]/admissions/international/undergraduate/edit/page.tsx
@@ -1,0 +1,28 @@
+import { putInternationalUndergraduateAction } from '@/actions/admissions';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_INTERNATIONAL_UNDERGRADUATE } from '@/constants/network';
+import { internationalUndergraduateAdmission } from '@/constants/segmentNode';
+import { getPath } from '@/utils/page';
+
+import AdmissionsEditor from '../../../components/AdmissionsEditor';
+
+const path = getPath(internationalUndergraduateAdmission);
+
+export default async function InternationalUndergraduateAdmissionEditPage() {
+  const data = await getAdmissions(
+    'international',
+    'undergraduate',
+    FETCH_TAG_INTERNATIONAL_UNDERGRADUATE,
+  );
+
+  return (
+    <PageLayout title="International Undergraduate Admission 편집" titleType="big">
+      <AdmissionsEditor
+        defaultValues={{ ko: data.ko.description, en: data.en.description }}
+        cancelPath={path}
+        onSubmit={putInternationalUndergraduateAction}
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/admissions/international/undergraduate/page.tsx
+++ b/app/[locale]/admissions/international/undergraduate/page.tsx
@@ -1,15 +1,13 @@
-import { Metadata } from 'next';
-
-import { getInternationalUndergraduate } from '@/apis/v2/admissions/international/undergraduate';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import { AdmissionPageProps } from '@/app/[locale]/admissions/type';
-import HTMLViewer from '@/components/form/html/HTMLViewer';
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_INTERNATIONAL_UNDERGRADUATE } from '@/constants/network';
 import { internationalUndergraduateAdmission } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
 
-export async function generateMetadata(props: {
-  params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
+import AdmissionsPageContent from '../../components/AdmissionsPageContent';
+
+export async function generateMetadata(props: { params: Promise<{ locale: string }> }) {
   const params = await props.params;
 
   const { locale } = params;
@@ -23,15 +21,17 @@ export async function generateMetadata(props: {
   });
 }
 
+const path = getPath(internationalUndergraduateAdmission);
+
 export default async function InternationalUndergraduateAdmissionPage({
   params,
 }: AdmissionPageProps) {
   const locale = (await params).locale;
-  const data = await getInternationalUndergraduate();
-
-  return (
-    <PageLayout titleType="big">
-      <HTMLViewer htmlContent={data[locale].description} />
-    </PageLayout>
+  const data = await getAdmissions(
+    'international',
+    'undergraduate',
+    FETCH_TAG_INTERNATIONAL_UNDERGRADUATE,
   );
+
+  return <AdmissionsPageContent pathname={path} description={data[locale].description} />;
 }

--- a/app/[locale]/admissions/page.tsx
+++ b/app/[locale]/admissions/page.tsx
@@ -1,12 +1,8 @@
-import { Metadata } from 'next';
-
 import MajorCategoryPageLayout from '@/components/layout/pageLayout/MajorCategoryPageLayout';
 import { admissions } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
 
-export async function generateMetadata(props: {
-  params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
+export async function generateMetadata(props: { params: Promise<{ locale: string }> }) {
   const params = await props.params;
 
   const { locale } = params;

--- a/app/[locale]/admissions/undergraduate/early-admission/edit/page.tsx
+++ b/app/[locale]/admissions/undergraduate/early-admission/edit/page.tsx
@@ -1,0 +1,24 @@
+import { putUndergraduateEarlyAdmissionsAction } from '@/actions/admissions';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_EARLY_ADMISSION } from '@/constants/network';
+import { undergraduateEarlyAdmission } from '@/constants/segmentNode';
+import { getPath } from '@/utils/page';
+
+import AdmissionsEditor from '../../../components/AdmissionsEditor';
+
+const path = getPath(undergraduateEarlyAdmission);
+
+export default async function UndergraduateEarlyAdmissionEditPage() {
+  const data = await getAdmissions('undergraduate', 'early-admission', FETCH_TAG_EARLY_ADMISSION);
+
+  return (
+    <PageLayout title="학부 수시 모집 수정" titleType="big">
+      <AdmissionsEditor
+        defaultValues={{ ko: data.ko.description, en: data.en.description }}
+        cancelPath={path}
+        onSubmit={putUndergraduateEarlyAdmissionsAction}
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/admissions/undergraduate/early-admission/page.tsx
+++ b/app/[locale]/admissions/undergraduate/early-admission/page.tsx
@@ -1,15 +1,13 @@
-import { Metadata } from 'next';
-
-import { getUndergraduateEarlyAdmission } from '@/apis/v2/admissions/undergraduate/early-admission';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import { AdmissionPageProps } from '@/app/[locale]/admissions/type';
-import HTMLViewer from '@/components/form/html/HTMLViewer';
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_EARLY_ADMISSION } from '@/constants/network';
 import { undergraduateEarlyAdmission } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
 
-export async function generateMetadata(props: {
-  params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
+import AdmissionsPageContent from '../../components/AdmissionsPageContent';
+
+export async function generateMetadata(props: { params: Promise<{ locale: string }> }) {
   const params = await props.params;
 
   const { locale } = params;
@@ -17,13 +15,11 @@ export async function generateMetadata(props: {
   return await getMetadata({ locale, node: undergraduateEarlyAdmission });
 }
 
+const path = getPath(undergraduateEarlyAdmission);
+
 export default async function UndergraduateEarlyAdmission({ params }: AdmissionPageProps) {
   const locale = (await params).locale;
-  const data = await getUndergraduateEarlyAdmission();
+  const data = await getAdmissions('undergraduate', 'early-admission', FETCH_TAG_EARLY_ADMISSION);
 
-  return (
-    <PageLayout titleType="big">
-      <HTMLViewer htmlContent={data[locale].description} />
-    </PageLayout>
-  );
+  return <AdmissionsPageContent pathname={path} description={data[locale].description} />;
 }

--- a/app/[locale]/admissions/undergraduate/regular-admission/edit/page.tsx
+++ b/app/[locale]/admissions/undergraduate/regular-admission/edit/page.tsx
@@ -1,0 +1,28 @@
+import { putUndergraduateRegularAdmissionsAction } from '@/actions/admissions';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_REGULAR_ADMISSON } from '@/constants/network';
+import { undergraduateScholarship } from '@/constants/segmentNode';
+import { getPath } from '@/utils/page';
+
+import AdmissionsEditor from '../../../components/AdmissionsEditor';
+
+const path = getPath(undergraduateScholarship);
+
+export default async function UndergraduateRegularAdmissionEditPage() {
+  const data = await getAdmissions(
+    'undergraduate',
+    'regular-admission',
+    FETCH_TAG_REGULAR_ADMISSON,
+  );
+
+  return (
+    <PageLayout title="학부 정시 모집 수정" titleType="big">
+      <AdmissionsEditor
+        defaultValues={{ ko: data.ko.description, en: data.en.description }}
+        cancelPath={path}
+        onSubmit={putUndergraduateRegularAdmissionsAction}
+      />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/admissions/undergraduate/regular-admission/edit/page.tsx
+++ b/app/[locale]/admissions/undergraduate/regular-admission/edit/page.tsx
@@ -1,19 +1,19 @@
 import { putUndergraduateRegularAdmissionsAction } from '@/actions/admissions';
 import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { FETCH_TAG_REGULAR_ADMISSON } from '@/constants/network';
-import { undergraduateScholarship } from '@/constants/segmentNode';
+import { FETCH_TAG_REGULAR_ADMISSION } from '@/constants/network';
+import { undergraduateRegularAdmission } from '@/constants/segmentNode';
 import { getPath } from '@/utils/page';
 
 import AdmissionsEditor from '../../../components/AdmissionsEditor';
 
-const path = getPath(undergraduateScholarship);
+const path = getPath(undergraduateRegularAdmission);
 
 export default async function UndergraduateRegularAdmissionEditPage() {
   const data = await getAdmissions(
     'undergraduate',
     'regular-admission',
-    FETCH_TAG_REGULAR_ADMISSON,
+    FETCH_TAG_REGULAR_ADMISSION,
   );
 
   return (

--- a/app/[locale]/admissions/undergraduate/regular-admission/page.tsx
+++ b/app/[locale]/admissions/undergraduate/regular-admission/page.tsx
@@ -1,6 +1,6 @@
 import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import { AdmissionPageProps } from '@/app/[locale]/admissions/type';
-import { FETCH_TAG_REGULAR_ADMISSON } from '@/constants/network';
+import { FETCH_TAG_REGULAR_ADMISSION } from '@/constants/network';
 import { undergraduateRegularAdmission } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
 import { getPath } from '@/utils/page';
@@ -22,7 +22,7 @@ export default async function UndergraduateRegularAdmission({ params }: Admissio
   const data = await getAdmissions(
     'undergraduate',
     'regular-admission',
-    FETCH_TAG_REGULAR_ADMISSON,
+    FETCH_TAG_REGULAR_ADMISSION,
   );
 
   return <AdmissionsPageContent pathname={path} description={data[locale].description} />;

--- a/app/[locale]/admissions/undergraduate/regular-admission/page.tsx
+++ b/app/[locale]/admissions/undergraduate/regular-admission/page.tsx
@@ -1,15 +1,13 @@
-import { Metadata } from 'next';
-
-import { getUndergraduateRegularAdmission } from '@/apis/v2/admissions/undergraduate/regular-admission';
+import { getAdmissions } from '@/apis/v2/admissions/[mainType]/[postType]';
 import { AdmissionPageProps } from '@/app/[locale]/admissions/type';
-import HTMLViewer from '@/components/form/html/HTMLViewer';
-import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { FETCH_TAG_REGULAR_ADMISSON } from '@/constants/network';
 import { undergraduateRegularAdmission } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
 
-export async function generateMetadata(props: {
-  params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
+import AdmissionsPageContent from '../../components/AdmissionsPageContent';
+
+export async function generateMetadata(props: { params: Promise<{ locale: string }> }) {
   const params = await props.params;
 
   const { locale } = params;
@@ -17,13 +15,15 @@ export async function generateMetadata(props: {
   return await getMetadata({ locale, node: undergraduateRegularAdmission });
 }
 
+const path = getPath(undergraduateRegularAdmission);
+
 export default async function UndergraduateRegularAdmission({ params }: AdmissionPageProps) {
   const locale = (await params).locale;
-  const data = await getUndergraduateRegularAdmission();
-
-  return (
-    <PageLayout titleType="big">
-      <HTMLViewer htmlContent={data[locale].description} />
-    </PageLayout>
+  const data = await getAdmissions(
+    'undergraduate',
+    'regular-admission',
+    FETCH_TAG_REGULAR_ADMISSON,
   );
+
+  return <AdmissionsPageContent pathname={path} description={data[locale].description} />;
 }

--- a/constants/network.ts
+++ b/constants/network.ts
@@ -42,4 +42,10 @@ export const FETCH_TAG_GROUP = 'group';
 export const FETCH_TAG_CENTER = 'center';
 export const FETCH_TAG_LAB = 'lab';
 
-export const FETCH_TAG_REGULAR_ADMISSON = 'regular-admission';
+export const FETCH_TAG_REGULAR_ADMISSION = 'regular-admission';
+export const FETCH_TAG_EARLY_ADMISSION = 'early-admission';
+export const FETCH_TAG_GRADUATE_ADMISSION = 'graduate-admission';
+export const FETCH_TAG_EXCHANGE = 'exchange-visiting';
+export const FETCH_TAG_INTERNATIONAL_SCHOLARSHIPS = 'international-scholarships';
+export const FETCH_TAG_INTERNATIONAL_GRADUATE = 'international-graduate';
+export const FETCH_TAG_INTERNATIONAL_UNDERGRADUATE = 'international-undergraduate';

--- a/constants/network.ts
+++ b/constants/network.ts
@@ -41,3 +41,5 @@ export const FETCH_TAG_CAREER = 'career';
 export const FETCH_TAG_GROUP = 'group';
 export const FETCH_TAG_CENTER = 'center';
 export const FETCH_TAG_LAB = 'lab';
+
+export const FETCH_TAG_REGULAR_ADMISSON = 'regular-admission';


### PR DESCRIPTION
## 작업 요약

- 입학 하위 페이지들 편집 기능 추가

## 상세 내용

- `AdmissionEditor` 구현
- 입학 공용 GET, PUT api 생성
  - 개별 api 제거
- 영문버전으로 전환했더니 description에 `<html> ...` 처럼 되어 있어서 에러 발생. 편집 기능 사용하여 정상적인 description으로 데이터 변경해서 해결.

## 테스트 방법

- 입학탭 하위 페이지들의 편집 기능 작동 확인
- 한영 변환 시 html 중복 마운팅 에러 없는지 확인

## 참고 문서
.
