### PR TITLE
✨ 활동보고 목록 페이지 구현

### DIFF
--- a/actions/council.ts
+++ b/actions/council.ts
@@ -5,7 +5,7 @@ import { revalidateTag } from 'next/cache';
 import { putCouncilIntro } from '@/apis/v2/council/intro';
 import { postCouncilReport } from '@/apis/v2/council/report';
 import { FETCH_TAG_COUNCIL_INTRO, FETCH_TAG_COUNCIL_REPORT } from '@/constants/network';
-import { councilIntro, councilReport } from '@/constants/segmentNode';
+import { councilIntro, councilReportList } from '@/constants/segmentNode';
 import { redirectKo } from '@/i18n/routing';
 import { getPath } from '@/utils/page';
 
@@ -19,7 +19,7 @@ export const putIntroAction = withErrorHandler(async (formData: FormData) => {
   redirectKo(introPath);
 });
 
-const councilReportPath = getPath(councilReport);
+const councilReportPath = getPath(councilReportList);
 
 export const postCouncilReportAction = withErrorHandler(async (formData: FormData) => {
   await postCouncilReport(formData);

--- a/apis/v2/council/report/index.ts
+++ b/apis/v2/council/report/index.ts
@@ -3,14 +3,16 @@ import { FETCH_TAG_COUNCIL_REPORT } from '@/constants/network';
 
 interface GETReportResponse {
   total: number;
-  reports: {
-    id: number;
-    title: string;
-    sequence: number;
-    name: string;
-    createdAt: string;
-    imageURL: string;
-  }[];
+  reports: CouncilReport[];
+}
+
+export interface CouncilReport {
+  id: number;
+  title: string;
+  sequence: number;
+  name: string;
+  createdAt: string;
+  imageURL: string;
 }
 
 export const getCouncilReportList = () =>

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -1,0 +1,5 @@
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+
+export default function CouncilReport({ params: { id } }: { params: { id: number } }) {
+  return <PageLayout titleType="big">CouncilReport {id}</PageLayout>;
+}

--- a/app/[locale]/community/council/report/assets/NaviBar_Close.svg
+++ b/app/[locale]/community/council/report/assets/NaviBar_Close.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.012 5.71373L26.2891 15.9908M26.2891 15.9908L16.012 26.2852M26.2891 15.9908L5.71764 15.9908" stroke="#0A0A0A" stroke-width="1.5"/>
+</svg>

--- a/app/[locale]/community/council/report/create/page.tsx
+++ b/app/[locale]/community/council/report/create/page.tsx
@@ -5,12 +5,12 @@ import CouncilReportEditor, {
   CouncilReportEditorContent,
 } from '@/app/[locale]/community/council/report/components/CouncilReportEditor';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
-import { councilReport } from '@/constants/segmentNode';
+import { councilReportList } from '@/constants/segmentNode';
 import { useRouter } from '@/i18n/routing';
 import { contentToFormData } from '@/utils/formData';
 import { getPath } from '@/utils/page';
 
-const councilReportListPath = getPath(councilReport);
+const councilReportListPath = getPath(councilReportList);
 
 export default function CouncilReportCreatePage() {
   const router = useRouter();

--- a/app/[locale]/community/council/report/page.tsx
+++ b/app/[locale]/community/council/report/page.tsx
@@ -1,10 +1,49 @@
-import { getCouncilReportList } from '@/apis/v2/council/report';
+import dayjs from 'dayjs';
+
+import { CouncilReport, getCouncilReportList } from '@/apis/v2/council/report';
+import Image from '@/components/common/Image';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { Link } from '@/i18n/routing';
+
+import NaviBarClose from './assets/NaviBar_Close.svg';
 
 export const dynamic = 'force-dynamic';
 
 export default async function CouncilIntroPage() {
-  const list = await getCouncilReportList();
+  const { reports } = await getCouncilReportList();
 
-  return <PageLayout titleType="big">{JSON.stringify(list)}</PageLayout>;
+  return (
+    <PageLayout titleType="big">
+      <div className="flex flex-wrap gap-[10px]">
+        {reports.map((report) => (
+          <Tile key={report.id} {...report} />
+        ))}
+      </div>
+    </PageLayout>
+  );
 }
+
+const Tile = ({ title, sequence, name, createdAt, imageURL }: CouncilReport) => {
+  const dateStr = dayjs(createdAt).format('YYYY/MM/DD');
+  return (
+    <Link className="group relative block h-[232px] w-[232px]" href="#">
+      <Image
+        src={imageURL}
+        alt=""
+        className="h-[232px] w-[232px] object-cover"
+        width={232}
+        height={232}
+      />
+      <div className="absolute bottom-0 left-0 right-0 top-0 flex flex-col justify-between border border-neutral-200 bg-neutral-100 px-[12px] py-[16px] opacity-0 transition-opacity group-hover:opacity-100">
+        <h3 className="text-[20px] font-semibold text-neutral-950">{title}</h3>
+        <div className="text-xs font-normal text-neutral-500">
+          <p>
+            제 {sequence}대 학생회 {name}
+          </p>
+          <p>{dateStr}</p>
+          <NaviBarClose className="absolute bottom-[16px] right-[12.5px]" />
+        </div>
+      </div>
+    </Link>
+  );
+};

--- a/app/[locale]/community/council/report/page.tsx
+++ b/app/[locale]/community/council/report/page.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 
 import { CouncilReport, getCouncilReportList } from '@/apis/v2/council/report';
 import Image from '@/components/common/Image';
+import LoginVisible from '@/components/common/LoginVisible';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { councilReportList } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
@@ -10,6 +11,8 @@ import { getPath } from '@/utils/page';
 import NaviBarClose from './assets/NaviBar_Close.svg';
 
 export const dynamic = 'force-dynamic';
+
+const path = getPath(councilReportList);
 
 export default async function CouncilReportList() {
   const { reports } = await getCouncilReportList();
@@ -21,11 +24,21 @@ export default async function CouncilReportList() {
           <Tile key={report.id} {...report} />
         ))}
       </div>
+      <LoginVisible>
+        <div className="mt-[40px] flex justify-end">
+          <Link href={`${path}/create`}>
+            <button
+              type="button"
+              className="ml-4 h-[2.1875rem] rounded-[0.0625rem] bg-neutral-800 px-3 text-md font-semibold leading-loose tracking-wider text-white enabled:hover:bg-neutral-500 disabled:opacity-30"
+            >
+              새 게시글
+            </button>
+          </Link>
+        </div>
+      </LoginVisible>
     </PageLayout>
   );
 }
-
-const path = getPath(councilReportList);
 
 const Tile = ({ id, title, sequence, name, createdAt, imageURL }: CouncilReport) => {
   const href = `${path}/${id}`;

--- a/app/[locale]/community/council/report/page.tsx
+++ b/app/[locale]/community/council/report/page.tsx
@@ -3,13 +3,15 @@ import dayjs from 'dayjs';
 import { CouncilReport, getCouncilReportList } from '@/apis/v2/council/report';
 import Image from '@/components/common/Image';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { councilReportList } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
+import { getPath } from '@/utils/page';
 
 import NaviBarClose from './assets/NaviBar_Close.svg';
 
 export const dynamic = 'force-dynamic';
 
-export default async function CouncilIntroPage() {
+export default async function CouncilReportList() {
   const { reports } = await getCouncilReportList();
 
   return (
@@ -23,10 +25,14 @@ export default async function CouncilIntroPage() {
   );
 }
 
-const Tile = ({ title, sequence, name, createdAt, imageURL }: CouncilReport) => {
+const path = getPath(councilReportList);
+
+const Tile = ({ id, title, sequence, name, createdAt, imageURL }: CouncilReport) => {
+  const href = `${path}/${id}`;
   const dateStr = dayjs(createdAt).format('YYYY/MM/DD');
+
   return (
-    <Link className="group relative block h-[232px] w-[232px]" href="#">
+    <Link className="group relative block h-[232px] w-[232px]" href={href}>
       <Image
         src={imageURL}
         alt=""

--- a/constants/segmentNode.ts
+++ b/constants/segmentNode.ts
@@ -150,7 +150,7 @@ export const councilBylaws: SegmentNode = {
   children: [],
 };
 
-export const councilReport: SegmentNode = {
+export const councilReportList: SegmentNode = {
   name: '활동 보고',
   segment: 'report',
   isPage: true,
@@ -610,7 +610,7 @@ about.children = [
   directions,
 ];
 community.children = [notice, news, seminar, facultyRecruitment, council];
-council.children = [councilIntro, councilBylaws, councilReport];
+council.children = [councilIntro, councilBylaws, councilReportList];
 people.children = [faculty, emeritusFaculty, staff];
 research.children = [researchGroups, researchCenters, researchLabs, topConferenceList];
 admissions.children = [undergraduateAdmission, graduateAdmission, internationalAdmission];


### PR DESCRIPTION
## 작업 요약

- 활동 보고 목록 페이지 구현
- 디버깅용 활동 보고 상세 페이지 구현

## 상세 내용

특정 페이지에서 사용되는 에셋은 해당 페이지 디랙토리의 `assets` 폴더에서 관리합니다. 

## 테스트 방법

활동 보고 목록 페이지 진입
- 로그인시 새 게시물 버튼 표시 및 동작 확인
- 타일 호버시 활동 보고 정보가 뜨는지 확인
- 타일 클릭시 활동 보고 페이지 이동 확인

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
