### PR TITLE
✨ 활동 보고 뷰어 구현

### DIFF
--- a/apis/types/council.ts
+++ b/apis/types/council.ts
@@ -1,0 +1,12 @@
+export interface Council {
+  id: number;
+  title: string;
+  description: string;
+  sequence: number;
+  name: string;
+  createdAt: string;
+  prevId: number;
+  prevTitle: string;
+  nextId: number;
+  nextTitle: string;
+}

--- a/apis/types/council.ts
+++ b/apis/types/council.ts
@@ -1,4 +1,4 @@
-export interface Council {
+export interface CouncilReport {
   id: number;
   title: string;
   description: string;

--- a/apis/v2/council/report/[id].ts
+++ b/apis/v2/council/report/[id].ts
@@ -1,14 +1,14 @@
 import { deleteRequest, getRequest, putRequest } from '@/apis';
-import { Council } from '@/apis/types/council';
+import { CouncilReport } from '@/apis/types/council';
 import { FETCH_TAG_COUNCIL_REPORT } from '@/constants/network';
 
 export const getCouncilReport = (id: number) =>
-  getRequest<Council>(`/v2/council/report/${id}`, undefined, {
+  getRequest<CouncilReport>(`/v2/council/report/${id}`, undefined, {
     next: { tags: [FETCH_TAG_COUNCIL_REPORT] },
   });
 
 export const putCouncilReport = (id: number, formData: FormData) =>
-  putRequest<Council>(`/v2/council/report/${id}`, {
+  putRequest<CouncilReport>(`/v2/council/report/${id}`, {
     body: formData,
     jsessionID: true,
   });

--- a/apis/v2/council/report/[id].ts
+++ b/apis/v2/council/report/[id].ts
@@ -1,26 +1,14 @@
 import { deleteRequest, getRequest, putRequest } from '@/apis';
+import { Council } from '@/apis/types/council';
 import { FETCH_TAG_COUNCIL_REPORT } from '@/constants/network';
 
-interface GETReportByIDResponse {
-  id: number;
-  title: string;
-  description: string;
-  sequence: number;
-  name: string;
-  createdAt: string;
-  prevId: number;
-  prevTitle: string;
-  nextId: number;
-  nextTitle: string;
-}
-
 export const getCouncilReport = (id: number) =>
-  getRequest<GETReportByIDResponse>(`/v2/council/report/${id}`, undefined, {
+  getRequest<Council>(`/v2/council/report/${id}`, undefined, {
     next: { tags: [FETCH_TAG_COUNCIL_REPORT] },
   });
 
 export const putCouncilReport = (id: number, formData: FormData) =>
-  putRequest<GETReportByIDResponse>(`/v2/council/report/${id}`, {
+  putRequest<Council>(`/v2/council/report/${id}`, {
     body: formData,
     jsessionID: true,
   });

--- a/app/[locale]/community/components/PostFooter.tsx
+++ b/app/[locale]/community/components/PostFooter.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from 'next-intl';
 
-import { Council } from '@/apis/types/council';
+import { CouncilReport } from '@/apis/types/council';
 import { News } from '@/apis/types/news';
 import { Notice } from '@/apis/types/notice';
 import { Seminar } from '@/apis/types/seminar';
@@ -12,7 +12,7 @@ import PostDeleteButton from './PostDeleteButton';
 
 type PostFooterProps = {
   postType: PostType;
-  post: Notice | News | Seminar | Council;
+  post: Notice | News | Seminar | CouncilReport;
   id?: string;
   margin?: string;
 };

--- a/app/[locale]/community/components/PostFooter.tsx
+++ b/app/[locale]/community/components/PostFooter.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from 'next-intl';
 
+import { Council } from '@/apis/types/council';
 import { News } from '@/apis/types/news';
 import { Notice } from '@/apis/types/notice';
 import { Seminar } from '@/apis/types/seminar';
@@ -11,7 +12,7 @@ import PostDeleteButton from './PostDeleteButton';
 
 type PostFooterProps = {
   postType: PostType;
-  post: Notice | News | Seminar;
+  post: Notice | News | Seminar | Council;
   id?: string;
   margin?: string;
 };
@@ -21,7 +22,7 @@ type AdjPost = {
   title: string;
 };
 
-type PostType = 'notice' | 'seminar' | 'news';
+type PostType = 'notice' | 'seminar' | 'news' | 'council/report';
 type RowType = 'next' | 'prev';
 
 export default function PostFooter({ post, margin = '', postType, id }: PostFooterProps) {

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -4,17 +4,31 @@ import dayjs from 'dayjs';
 import { getTranslations } from 'next-intl/server';
 
 import { CouncilReport } from '@/apis/types/council';
+import { getCouncilReport } from '@/apis/v2/council/report/[id]';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import { StraightNode } from '@/components/common/Nodes';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
 import { PAGE_PADDING_BOTTOM_TAILWIND } from '@/components/layout/pageLayout/paddings';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { councilReportList } from '@/constants/segmentNode';
+import { getMetadata } from '@/utils/metadata';
 
-export default async function CouncilReportPage({
-  params,
-}: {
+interface Props {
   params: Promise<{ id: number; locale: string }>;
-}) {
+}
+
+export async function generateMetadata({ params }: Props) {
+  const { locale, id } = await params;
+  const { title } = await getCouncilReport(id);
+
+  return await getMetadata({
+    locale,
+    node: councilReportList,
+    metadata: { title },
+  });
+}
+
+export default async function CouncilReportPage({ params }: Props) {
   const { id, locale } = await params;
   const t = await getTranslations({ locale });
 

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -4,7 +4,6 @@ import dayjs from 'dayjs';
 import { getTranslations } from 'next-intl/server';
 
 import { CouncilReport } from '@/apis/types/council';
-import { getCouncilReport } from '@/apis/v2/council/report/[id]';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import { StraightNode } from '@/components/common/Nodes';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
@@ -13,13 +12,27 @@ import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { councilReportList } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
 
+const council: CouncilReport = {
+  id: 2,
+  title: 'title',
+  description: 'description',
+  sequence: 1,
+  name: 'name',
+  createdAt: '2022-01-01T00:00:00.000Z',
+  prevId: 1,
+  prevTitle: 'prevTitle',
+  nextId: 3,
+  nextTitle: 'nextTitle',
+};
+
 interface Props {
   params: Promise<{ id: number; locale: string }>;
 }
 
 export async function generateMetadata({ params }: Props) {
-  const { locale, id } = await params;
-  const { title } = await getCouncilReport(id);
+  const { locale } = await params;
+  // const { title } = await getCouncilReport(id);
+  const { title } = council;
 
   return await getMetadata({
     locale,
@@ -33,18 +46,6 @@ export default async function CouncilReportPage({ params }: Props) {
   const t = await getTranslations({ locale });
 
   // const council = await getCouncilReport(id);
-  const council: CouncilReport = {
-    id: 2,
-    title: 'title',
-    description: 'description',
-    sequence: 1,
-    name: 'name',
-    createdAt: '2022-01-01T00:00:00.000Z',
-    prevId: 1,
-    prevTitle: 'prevTitle',
-    nextId: 3,
-    nextTitle: 'nextTitle',
-  };
 
   const { title, description, sequence, name, createdAt } = council;
   const author = `제${sequence}대 학생회 ${name}`;

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -1,5 +1,49 @@
+import 'dayjs/locale/ko';
+
+import dayjs from 'dayjs';
+import { getTranslations } from 'next-intl/server';
+
+import { getCouncilReport } from '@/apis/v2/council/report/[id]';
+import PostFooter from '@/app/[locale]/community/components/PostFooter';
+import { StraightNode } from '@/components/common/Nodes';
+import HTMLViewer from '@/components/form/html/HTMLViewer';
+import { PAGE_PADDING_BOTTOM_TAILWIND } from '@/components/layout/pageLayout/paddings';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 
-export default function CouncilReport({ params: { id } }: { params: { id: number } }) {
-  return <PageLayout titleType="big">CouncilReport {id}</PageLayout>;
+export default async function CouncilReport({
+  params,
+}: {
+  params: Promise<{ id: number; locale: string }>;
+}) {
+  const { id, locale } = await params;
+  const t = await getTranslations({ locale });
+  const council = await getCouncilReport(id);
+
+  const { title, description, sequence, name, createdAt } = council;
+  const author = `제${sequence}대 학생회 ${name}`;
+  const dateStr = dayjs(createdAt).locale('ko').format('YYYY/MM/DD (ddd) A h:mm');
+
+  return (
+    <PageLayout titleType="big" removePadding>
+      <div className="flex flex-col gap-4 px-5 py-9 sm:pl-[100px] sm:pr-[340px]">
+        <h2 className="text-[1.25rem] font-semibold leading-[1.4]">{title}</h2>
+        <div className="flex gap-5 text-sm font-normal tracking-wide text-neutral-500">
+          <p>
+            {t('작성자')}: {author}
+          </p>
+          <p>
+            {t('작성 날짜')}: {dateStr}
+          </p>
+        </div>
+      </div>
+
+      <div
+        className={`bg-neutral-50 px-5 pt-9 sm:pl-[100px] sm:pr-[340px] ${PAGE_PADDING_BOTTOM_TAILWIND}`}
+      >
+        <HTMLViewer htmlContent={description} wrapperClassName="mb-10" />
+        <StraightNode />
+        <PostFooter post={council} postType="council/report" id={id.toString()} margin="mt-12" />
+      </div>
+    </PageLayout>
+  );
 }

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -3,7 +3,7 @@ import 'dayjs/locale/ko';
 import dayjs from 'dayjs';
 import { getTranslations } from 'next-intl/server';
 
-import { getCouncilReport } from '@/apis/v2/council/report/[id]';
+import { Council } from '@/apis/types/council';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import { StraightNode } from '@/components/common/Nodes';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
@@ -17,7 +17,20 @@ export default async function CouncilReport({
 }) {
   const { id, locale } = await params;
   const t = await getTranslations({ locale });
-  const council = await getCouncilReport(id);
+
+  // const council = await getCouncilReport(id);
+  const council: Council = {
+    id: 2,
+    title: 'title',
+    description: 'description',
+    sequence: 1,
+    name: 'name',
+    createdAt: '2022-01-01T00:00:00.000Z',
+    prevId: 1,
+    prevTitle: 'prevTitle',
+    nextId: 3,
+    nextTitle: 'nextTitle',
+  };
 
   const { title, description, sequence, name, createdAt } = council;
   const author = `제${sequence}대 학생회 ${name}`;

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -3,14 +3,14 @@ import 'dayjs/locale/ko';
 import dayjs from 'dayjs';
 import { getTranslations } from 'next-intl/server';
 
-import { Council } from '@/apis/types/council';
+import { CouncilReport } from '@/apis/types/council';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import { StraightNode } from '@/components/common/Nodes';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
 import { PAGE_PADDING_BOTTOM_TAILWIND } from '@/components/layout/pageLayout/paddings';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 
-export default async function CouncilReport({
+export default async function CouncilReportPage({
   params,
 }: {
   params: Promise<{ id: number; locale: string }>;
@@ -19,7 +19,7 @@ export default async function CouncilReport({
   const t = await getTranslations({ locale });
 
   // const council = await getCouncilReport(id);
-  const council: Council = {
+  const council: CouncilReport = {
     id: 2,
     title: 'title',
     description: 'description',

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   'src/**/*.{js,ts,jsx,tsx}': ['eslint --fix', 'prettier --write'],
   '!(src/**/*.{js,ts,jsx,tsx})': 'prettier --ignore-unknown --write',
-  '**/*.ts?(x)': () => 'tsc --noEmit',
+  '**/*.ts?(x)': () => 'tsc -p tsconfig.json --noEmit',
 };


### PR DESCRIPTION
## 작업 요약

- PostFooter에 CouncilReport 지원 추가
- CouncilReportPage 구현 

## 상세 내용

lint-staged에서 tsc로 타입 검사할 때 .next 폴더를 검사하는 이슈가 있어 공식 문서 참고해 `-p tsconfig.json` 플래그 추가함. tsconfig에 include를 보고 거기만 검사하지 않을까... 예상중. 

api에서 500이 내려와 임시로 목데이터 사용중. 

## 테스트 방법

활동 보고 상세 페이지 진입해 아래 확인

- 내용 잘 뜨는지
- 번역 잘 되는지
- 편집, 삭제 버튼 잘 되는지
- 이전글 다음글 잘 가는지

## 참고 문서

https://github.com/lint-staged/lint-staged?tab=readme-ov-file#example-run-tsc-on-changes-to-typescript-files-but-do-not-pass-any-filename-arguments
