### PR TITLE
💄 학생회 UI qa 반영

### DIFF
--- a/app/[locale]/community/council/page.tsx
+++ b/app/[locale]/community/council/page.tsx
@@ -1,4 +1,5 @@
 import MajorCategoryPageLayout from '@/components/layout/pageLayout/MajorCategoryPageLayout';
+import PageTitle from '@/components/layout/pageLayout/PageTitle';
 import { council } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
 
@@ -11,5 +12,17 @@ export async function generateMetadata(props: { params: Promise<{ locale: string
 }
 
 export default async function CouncilPage() {
-  return <MajorCategoryPageLayout theme="light" />;
+  return (
+    <MajorCategoryPageLayout
+      theme="light"
+      titleComponent={
+        <PageTitle
+          title={council.name}
+          currentPage={council}
+          titleType="big"
+          margin="mb-6 sm:mb-11"
+        />
+      }
+    />
+  );
 }

--- a/app/[locale]/community/council/page.tsx
+++ b/app/[locale]/community/council/page.tsx
@@ -1,4 +1,5 @@
-import MajorCategoryPageLayout from '@/components/layout/pageLayout/MajorCategoryPageLayout';
+import Header from '@/components/layout/header/Header';
+import CategoryGrid from '@/components/layout/pageLayout/CategoryGrid';
 import PageTitle from '@/components/layout/pageLayout/PageTitle';
 import { council } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
@@ -13,16 +14,15 @@ export async function generateMetadata(props: { params: Promise<{ locale: string
 
 export default async function CouncilPage() {
   return (
-    <MajorCategoryPageLayout
-      theme="light"
-      titleComponent={
-        <PageTitle
-          title={council.name}
-          currentPage={council}
-          titleType="big"
-          margin="mb-6 sm:mb-11"
-        />
-      }
-    />
+    <div className="bg-neutral-850">
+      <Header />
+      <PageTitle
+        title={council.name}
+        currentPage={council}
+        titleType="big"
+        margin="mb-6 sm:mb-11"
+      />
+      <CategoryGrid currentPage={council} theme="light" />
+    </div>
   );
 }

--- a/components/layout/pageLayout/CategoryGrid.tsx
+++ b/components/layout/pageLayout/CategoryGrid.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+import { SegmentNode } from '@/constants/segmentNode';
+import { useRouter } from '@/i18n/routing';
+import { getPath } from '@/utils/page';
+
+import ENG_NAMES from '../../../messages/en.json';
+
+// TODO: RootItem을 클릭했을 때 LeafItem이 보이도록 자동 스크롤
+export default function CategoryGrid({
+  currentPage,
+  theme,
+}: {
+  currentPage: SegmentNode;
+  theme: 'light' | 'dark';
+}) {
+  const t = useTranslations('Nav');
+
+  // 학사 및 교과 등에서 소분류 선택 처리용 state
+  const [selectedCategory, setSelectedCategory] = useState<SegmentNode | null>(null);
+  const router = useRouter();
+
+  return (
+    <div
+      className={`${theme === 'light' ? 'bg-white' : 'bg-neutral-900'} px-5 py-7 sm:px-[6.25rem] sm:pb-[11.25rem] sm:pt-20`}
+    >
+      <div className="mb-5 grid grid-cols-[repeat(2,_1fr)] gap-9 sm:mb-10 sm:grid-cols-[repeat(auto-fill,_300px)] sm:gap-9">
+        {currentPage.children!.map((subpage, index) => (
+          <RootItem
+            key={index}
+            title={t(subpage.name)}
+            onClick={() =>
+              subpage.isPage ? router.push(getPath(subpage)) : setSelectedCategory(subpage)
+            }
+            isSelected={selectedCategory == subpage}
+            isLight={theme === 'light'}
+            isPage={subpage.isPage}
+          />
+        ))}
+      </div>
+
+      {selectedCategory && !selectedCategory.isPage && (
+        <div className="grid grid-cols-[repeat(2,_1fr)] gap-5 sm:mb-10 sm:grid-cols-[repeat(auto-fill,_300px)] sm:gap-10">
+          {selectedCategory.children!.map((subpage, index) => (
+            <LeafItem
+              key={index}
+              title={subpage.name}
+              onClick={() => router.push(getPath(subpage))}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface RootItemProps {
+  title: string;
+  isPage: boolean;
+  isSelected?: boolean;
+  onClick: () => void;
+  isLight?: boolean;
+}
+
+function RootItem({ title, isPage, isSelected, isLight, onClick }: RootItemProps) {
+  const bgColor = isSelected ? 'bg-main-orange-dark' : isLight ? 'bg-neutral-50' : 'bg-neutral-100';
+
+  return (
+    <DetailItem
+      title={title}
+      onClick={onClick}
+      hasArrow={isPage}
+      bgColor={bgColor}
+      hoverColor={isLight ? 'bg-neutral-200' : 'bg-main-orange-dark'}
+      borderColor={isLight ? 'border-neutral-200' : undefined}
+    />
+  );
+}
+interface LeafItemProps {
+  title: string;
+  onClick: () => void;
+}
+
+function LeafItem({ title, onClick }: LeafItemProps) {
+  return (
+    <DetailItem
+      title={title}
+      onClick={onClick}
+      hasArrow
+      bgColor="bg-neutral-400"
+      hoverColor="bg-neutral-500"
+    />
+  );
+}
+
+interface DetailItemProps {
+  title: string;
+  hasArrow: boolean;
+  bgColor: string;
+  hoverColor?: string;
+  borderColor?: string;
+  onClick: () => void;
+}
+
+function DetailItem({
+  title,
+  hasArrow,
+  bgColor,
+  hoverColor,
+  borderColor,
+  onClick,
+}: DetailItemProps) {
+  const hoverBgColor = hoverColor ? `hover:${hoverColor}` : 'hover:bg-main-orange-dark';
+
+  return (
+    <div
+      className={`group h-[96px] sm:h-[160px] ${bgColor} ${borderColor && `border ${borderColor}`} px-[14px] py-[13px] sm:px-7 sm:py-6 ${hoverBgColor} flex cursor-pointer flex-col justify-between duration-300`}
+      onClick={onClick}
+    >
+      <div>
+        <h3 className="mb-[0.625rem] text-md font-medium text-neutral-800 sm:mb-2.5 sm:text-[20px]">
+          {title}
+        </h3>
+        <p className="text-[11px] text-neutral-800 sm:text-base">
+          {ENG_NAMES.Nav[title as keyof typeof ENG_NAMES.Nav] ?? ''}
+        </p>
+      </div>
+      {hasArrow && (
+        <div className="text-end">
+          <span className="material-symbols-outlined text-[18px] font-extralight text-neutral-800 duration-300 group-hover:translate-x-[10px] sm:text-[32px]">
+            arrow_forward
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/layout/pageLayout/MajorCategoryPageLayout.tsx
+++ b/components/layout/pageLayout/MajorCategoryPageLayout.tsx
@@ -51,7 +51,6 @@ export default function MajorCategoryPageLayout({
             <HTMLViewer
               htmlContent={description}
               wrapperClassName="mb-6 mt-8 hidden sm:block"
-              // contentClassName={{ color: '#f5f5f5', maxWidth: 960 }}
               contentClassName="!text-[#f5f5f5] max-w-[960px]"
             />
           )}

--- a/components/layout/pageLayout/MajorCategoryPageLayout.tsx
+++ b/components/layout/pageLayout/MajorCategoryPageLayout.tsx
@@ -1,32 +1,23 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { ReactNode, useState } from 'react';
 
 import HTMLViewer from '@/components/form/html/HTMLViewer';
-import { SegmentNode } from '@/constants/segmentNode';
-import { useRouter } from '@/i18n/routing';
 import useCurrentSegmentNode from '@/utils/hooks/useCurrentSegmentNode';
-import { getPath } from '@/utils/page';
 
-import ENG_NAMES from '../../../messages/en.json';
 import Header from '../header/Header';
+import CategoryGrid from './CategoryGrid';
 
 interface GuidePageLayoutProps {
   title?: string;
   subtitle?: string;
   description?: string;
-  theme?: 'light' | 'dark';
-  titleComponent?: ReactNode;
 }
 
-// TODO: RootItem을 클릭했을 때 LeafItem이 보이도록 자동 스크롤
 export default function MajorCategoryPageLayout({
   title,
   subtitle = '',
   description = '',
-  theme = 'dark',
-  titleComponent,
 }: GuidePageLayoutProps) {
   const t = useTranslations('Nav');
   const currentPage = useCurrentSegmentNode();
@@ -34,148 +25,31 @@ export default function MajorCategoryPageLayout({
   // TODO: messages.json에 번역 파일 추가
   title ||= t(currentPage.name);
 
-  // 학사 및 교과 등에서 소분류 선택 처리용 state
-  const [selectedCategory, setSelectedCategory] = useState<SegmentNode | null>(null);
-  const router = useRouter();
-
   return (
     <div className="bg-neutral-850">
       <Header />
-      {titleComponent || (
-        <div className="max-w-[80rem] px-5 py-8 sm:px-[6.25rem] sm:pb-[4.5rem] sm:pt-12">
-          <div className="text:sm mb-2 font-light text-neutral-500 sm:text-[20px]">{subtitle}</div>
-          <div className="text-[32px] font-semibold tracking-wide text-white sm:text-[64px]">
-            {title}
-          </div>
-          {description && (
-            <HTMLViewer
-              htmlContent={description}
-              wrapperClassName="mb-6 mt-8 hidden sm:block"
-              contentClassName="!text-[#f5f5f5] max-w-[960px]"
-            />
-          )}
+      <div className="max-w-[80rem] px-5 py-8 sm:px-[6.25rem] sm:pb-[4.5rem] sm:pt-12">
+        <div className="text:sm mb-2 font-light text-neutral-500 sm:text-[20px]">{subtitle}</div>
+        <div className="text-[32px] font-semibold tracking-wide text-white sm:text-[64px]">
+          {title}
         </div>
-      )}
-      <div
-        className={`${theme === 'light' ? 'bg-white' : 'bg-neutral-900'} px-5 pt-7 ${
-          !description && 'pb-16'
-        } sm:px-[6.25rem] sm:pb-[11.25rem] sm:pt-20`}
-      >
-        <div className="mb-5 grid grid-cols-[repeat(2,_1fr)] gap-9 sm:mb-10 sm:grid-cols-[repeat(auto-fill,_300px)] sm:gap-9">
-          {currentPage.children!.map((subpage, index) => (
-            <RootItem
-              key={index}
-              title={t(subpage.name)}
-              onClick={() =>
-                subpage.isPage ? router.push(getPath(subpage)) : setSelectedCategory(subpage)
-              }
-              isSelected={selectedCategory == subpage}
-              isLight={theme === 'light'}
-              isPage={subpage.isPage}
-            />
-          ))}
-        </div>
-
-        {selectedCategory && !selectedCategory.isPage && (
-          <div className="grid grid-cols-[repeat(2,_1fr)] gap-5 sm:mb-10 sm:grid-cols-[repeat(auto-fill,_300px)] sm:gap-10">
-            {selectedCategory.children!.map((subpage, index) => (
-              <LeafItem
-                key={index}
-                title={subpage.name}
-                onClick={() => router.push(getPath(subpage))}
-              />
-            ))}
-          </div>
+        {description && (
+          // 웹버전 description
+          <HTMLViewer
+            htmlContent={description}
+            wrapperClassName="mb-6 mt-8 hidden sm:block"
+            contentClassName="!text-[#f5f5f5] max-w-[960px]"
+          />
         )}
       </div>
+      <CategoryGrid currentPage={currentPage} theme="dark" />
       {description && (
-        <div className="px-5 pb-24 pt-6 sm:hidden">
+        // 모바일 버전 description
+        <div className="px-5 pb-14 pt-7 sm:hidden">
           <HTMLViewer
             htmlContent={description}
             contentClassName="!text-[#a3a3a3] font-light text-[13px]"
           />
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface RootItemProps {
-  title: string;
-  isPage: boolean;
-  isSelected?: boolean;
-  onClick: () => void;
-  isLight?: boolean;
-}
-
-function RootItem({ title, isPage, isSelected, isLight, onClick }: RootItemProps) {
-  const bgColor = isSelected ? 'bg-main-orange-dark' : isLight ? 'bg-neutral-50' : 'bg-neutral-100';
-
-  return (
-    <DetailItem
-      title={title}
-      onClick={onClick}
-      hasArrow={isPage}
-      bgColor={bgColor}
-      hoverColor={isLight ? 'bg-neutral-200' : 'bg-main-orange-dark'}
-      borderColor={isLight ? 'border-neutral-200' : undefined}
-    />
-  );
-}
-interface LeafItemProps {
-  title: string;
-  onClick: () => void;
-}
-
-function LeafItem({ title, onClick }: LeafItemProps) {
-  return (
-    <DetailItem
-      title={title}
-      onClick={onClick}
-      hasArrow
-      bgColor="bg-neutral-400"
-      hoverColor="bg-neutral-500"
-    />
-  );
-}
-
-interface DetailItemProps {
-  title: string;
-  hasArrow: boolean;
-  bgColor: string;
-  hoverColor?: string;
-  borderColor?: string;
-  onClick: () => void;
-}
-
-function DetailItem({
-  title,
-  hasArrow,
-  bgColor,
-  hoverColor,
-  borderColor,
-  onClick,
-}: DetailItemProps) {
-  const hoverBgColor = hoverColor ? `hover:${hoverColor}` : 'hover:bg-main-orange-dark';
-
-  return (
-    <div
-      className={`group h-[96px] sm:h-[160px] ${bgColor} ${borderColor && `border ${borderColor}`} px-[14px] py-[13px] sm:px-7 sm:py-6 ${hoverBgColor} flex cursor-pointer flex-col justify-between duration-300`}
-      onClick={onClick}
-    >
-      <div>
-        <h3 className="mb-[0.625rem] text-md font-medium text-neutral-800 sm:mb-2.5 sm:text-[20px]">
-          {title}
-        </h3>
-        <p className="text-[11px] text-neutral-800 sm:text-base">
-          {ENG_NAMES.Nav[title as keyof typeof ENG_NAMES.Nav] ?? ''}
-        </p>
-      </div>
-      {hasArrow && (
-        <div className="text-end">
-          <span className="material-symbols-outlined text-[18px] font-extralight text-neutral-800 duration-300 group-hover:translate-x-[10px] sm:text-[32px]">
-            arrow_forward
-          </span>
         </div>
       )}
     </div>

--- a/components/layout/pageLayout/MajorCategoryPageLayout.tsx
+++ b/components/layout/pageLayout/MajorCategoryPageLayout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 import HTMLViewer from '@/components/form/html/HTMLViewer';
 import { SegmentNode } from '@/constants/segmentNode';
@@ -17,6 +17,7 @@ interface GuidePageLayoutProps {
   subtitle?: string;
   description?: string;
   theme?: 'light' | 'dark';
+  titleComponent?: ReactNode;
 }
 
 // TODO: RootItem을 클릭했을 때 LeafItem이 보이도록 자동 스크롤
@@ -25,6 +26,7 @@ export default function MajorCategoryPageLayout({
   subtitle = '',
   description = '',
   theme = 'dark',
+  titleComponent,
 }: GuidePageLayoutProps) {
   const t = useTranslations('Nav');
   const currentPage = useCurrentSegmentNode();
@@ -39,20 +41,22 @@ export default function MajorCategoryPageLayout({
   return (
     <div className="bg-neutral-850">
       <Header />
-      <div className="max-w-[80rem] px-5 py-8 sm:px-[6.25rem] sm:pb-[4.5rem] sm:pt-12">
-        <div className="text:sm mb-2 font-light text-neutral-500 sm:text-[20px]">{subtitle}</div>
-        <div className="text-[32px] font-semibold tracking-wide text-white sm:text-[64px]">
-          {title}
+      {titleComponent || (
+        <div className="max-w-[80rem] px-5 py-8 sm:px-[6.25rem] sm:pb-[4.5rem] sm:pt-12">
+          <div className="text:sm mb-2 font-light text-neutral-500 sm:text-[20px]">{subtitle}</div>
+          <div className="text-[32px] font-semibold tracking-wide text-white sm:text-[64px]">
+            {title}
+          </div>
+          {description && (
+            <HTMLViewer
+              htmlContent={description}
+              wrapperClassName="mb-6 mt-8 hidden sm:block"
+              // contentClassName={{ color: '#f5f5f5', maxWidth: 960 }}
+              contentClassName="!text-[#f5f5f5] max-w-[960px]"
+            />
+          )}
         </div>
-        {description && (
-          <HTMLViewer
-            htmlContent={description}
-            wrapperClassName="mb-6 mt-8 hidden sm:block"
-            // contentClassName={{ color: '#f5f5f5', maxWidth: 960 }}
-            contentClassName="!text-[#f5f5f5] max-w-[960px]"
-          />
-        )}
-      </div>
+      )}
       <div
         className={`${theme === 'light' ? 'bg-white' : 'bg-neutral-900'} px-5 pt-7 ${
           !description && 'pb-16'

--- a/components/layout/pageLayout/SubNavbar.tsx
+++ b/components/layout/pageLayout/SubNavbar.tsx
@@ -2,7 +2,7 @@ import { useTranslations } from 'next-intl';
 
 import { CurvedVerticalNode } from '@/components/common/Nodes';
 import NavLabel from '@/components/layout/navbar/NavLabel';
-import { community, council, SegmentNode } from '@/constants/segmentNode';
+import { council, SegmentNode } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
 import useStyle from '@/utils/hooks/useStyle';
 import { getAllSubTabs, getDepth, getPath, getRootTab } from '@/utils/page';
@@ -20,11 +20,8 @@ const INDENTATION = 16;
 export default function SubNavbar({ currentTab }: { currentTab: TreeNode }) {
   const t = useTranslations('Nav');
   const rootTab = getRootTab(currentTab as SegmentNode);
-  const subTabs =
-    // 학생회 하위 탭은 서브내비 노출 X
-    rootTab === community
-      ? getAllSubTabs(rootTab).filter((tab) => tab.parent !== council)
-      : getAllSubTabs(rootTab);
+  // 학생회 하위 탭은 서브내비 노출 X
+  const subTabs = getAllSubTabs(rootTab).filter((tab) => tab.parent !== council);
 
   const height = `${(subTabs.length + 1) * ITEM_HEIGHT}px`;
 

--- a/components/layout/pageLayout/SubNavbar.tsx
+++ b/components/layout/pageLayout/SubNavbar.tsx
@@ -2,7 +2,7 @@ import { useTranslations } from 'next-intl';
 
 import { CurvedVerticalNode } from '@/components/common/Nodes';
 import NavLabel from '@/components/layout/navbar/NavLabel';
-import { SegmentNode } from '@/constants/segmentNode';
+import { community, council, SegmentNode } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
 import useStyle from '@/utils/hooks/useStyle';
 import { getAllSubTabs, getDepth, getPath, getRootTab } from '@/utils/page';
@@ -20,7 +20,12 @@ const INDENTATION = 16;
 export default function SubNavbar({ currentTab }: { currentTab: TreeNode }) {
   const t = useTranslations('Nav');
   const rootTab = getRootTab(currentTab as SegmentNode);
-  const subTabs = getAllSubTabs(rootTab);
+  const subTabs =
+    // 학생회 하위 탭은 서브내비 노출 X
+    rootTab === community
+      ? getAllSubTabs(rootTab).filter((tab) => tab.parent !== council)
+      : getAllSubTabs(rootTab);
+
   const height = `${(subTabs.length + 1) * ITEM_HEIGHT}px`;
 
   return (

--- a/utils/page.ts
+++ b/utils/page.ts
@@ -25,8 +25,6 @@ export const getRootTab = (currTab: SegmentNode): SegmentNode => {
 };
 
 export const getAllSubTabs = (rootTab: SegmentNode): SegmentNode[] => {
-  if (!rootTab.children) return [];
-
   const subtabs: SegmentNode[] = [];
   for (const subtab of rootTab.children) {
     subtabs.push(subtab);


### PR DESCRIPTION
## 작업 요약

- 학생회 중분류 페이지 헤더 작게 변경
- 서브내비에서 학생회 하위탭은 보이지 않도록 처리

## 상세 내용

- `MajorCategoryPageLayout` 컴포넌트에서 타이틀 컴포넌트 별도로 받을 수 있도록 확장
- 서브내비 컴포넌트에서 학생회 하위탭 분기처리
- `SegmentNode`의 `children` 속성이 필수이므로 `getAllSubTabs`의 첫번째 줄은 의미 없는 코드가 되어 제거

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
