### PR TITLE
✨ 학생회 활동보고 편집 페이지 구현

### DIFF
--- a/actions/council.ts
+++ b/actions/council.ts
@@ -9,7 +9,7 @@ import {
   putCouncilMinute,
 } from '@/apis/v2/council/meeting-minute';
 import { postCouncilReport } from '@/apis/v2/council/report';
-import { deleteCouncilReport } from '@/apis/v2/council/report/[id]';
+import { deleteCouncilReport, putCouncilReport } from '@/apis/v2/council/report/[id]';
 import {
   FETCH_TAG_COUNCIL_INTRO,
   FETCH_TAG_COUNCIL_MINUTE,
@@ -67,6 +67,12 @@ export const postCouncilReportAction = withErrorHandler(async (formData: FormDat
   await postCouncilReport(formData);
   revalidateTag(FETCH_TAG_COUNCIL_REPORT);
   redirectKo(councilReportPath);
+});
+
+export const putCouncilReportAction = withErrorHandler(async (id: number, formData: FormData) => {
+  await putCouncilReport(id, formData);
+  revalidateTag(FETCH_TAG_COUNCIL_REPORT);
+  redirectKo(`${councilReportPath}/${id}`);
 });
 
 export const deleteCouncilReportAction = async (id: number) => {

--- a/actions/council.ts
+++ b/actions/council.ts
@@ -9,6 +9,7 @@ import {
   putCouncilMinute,
 } from '@/apis/v2/council/meeting-minute';
 import { postCouncilReport } from '@/apis/v2/council/report';
+import { deleteCouncilReport } from '@/apis/v2/council/report/[id]';
 import {
   FETCH_TAG_COUNCIL_INTRO,
   FETCH_TAG_COUNCIL_MINUTE,
@@ -67,3 +68,13 @@ export const postCouncilReportAction = withErrorHandler(async (formData: FormDat
   revalidateTag(FETCH_TAG_COUNCIL_REPORT);
   redirectKo(councilReportPath);
 });
+
+export const deleteCouncilReportAction = async (id: number) => {
+  try {
+    await deleteCouncilReport(id);
+    revalidateTag(FETCH_TAG_COUNCIL_REPORT);
+  } catch (error) {
+    return { message: error instanceof Error ? error.message : '알 수 없는 에러: ' + error };
+  }
+  redirectKo(councilReportPath);
+};

--- a/apis/types/council.ts
+++ b/apis/types/council.ts
@@ -17,4 +17,5 @@ export interface CouncilReport {
   prevTitle: string;
   nextId: number;
   nextTitle: string;
+  imageURL: string;
 }

--- a/apis/v2/council/report/[id].ts
+++ b/apis/v2/council/report/[id].ts
@@ -13,6 +13,5 @@ export const putCouncilReport = (id: number, formData: FormData) =>
     jsessionID: true,
   });
 
-export const deleteCouncilReport = (id: number) => {
-  return deleteRequest(`/v2/council/report/${id}`, { jsessionID: true });
-};
+export const deleteCouncilReport = (id: number) =>
+  deleteRequest(`/v2/council/report/${id}`, { jsessionID: true });

--- a/app/[locale]/community/components/PostDeleteButton.tsx
+++ b/app/[locale]/community/components/PostDeleteButton.tsx
@@ -2,6 +2,7 @@
 
 import { useTransition } from 'react';
 
+import { deleteCouncilReportAction } from '@/actions/council';
 import { deleteNewsAction } from '@/actions/news';
 import { deleteNoticeAction } from '@/actions/notice';
 import { deleteSeminarAction } from '@/actions/seminar';
@@ -27,6 +28,8 @@ export default function PostDeleteButton({ postType, id }: { postType: string; i
         return deleteNewsAction;
       case 'seminar':
         return deleteSeminarAction;
+      case 'council/report':
+        return deleteCouncilReportAction;
     }
   };
 

--- a/app/[locale]/community/components/PostFooter.tsx
+++ b/app/[locale]/community/components/PostFooter.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl';
 import { CouncilReport } from '@/apis/types/council';
 import { News } from '@/apis/types/news';
 import { Notice } from '@/apis/types/notice';
+import { Role } from '@/apis/types/role';
 import { Seminar } from '@/apis/types/seminar';
 import LoginVisible from '@/components/common/LoginVisible';
 import { Link } from '@/i18n/routing';
@@ -15,6 +16,7 @@ type PostFooterProps = {
   post: Notice | News | Seminar | CouncilReport;
   id?: string;
   margin?: string;
+  role?: Role[] | Role;
 };
 
 type AdjPost = {
@@ -25,7 +27,13 @@ type AdjPost = {
 type PostType = 'notice' | 'seminar' | 'news' | 'council/report';
 type RowType = 'next' | 'prev';
 
-export default function PostFooter({ post, margin = '', postType, id }: PostFooterProps) {
+export default function PostFooter({
+  post,
+  margin = '',
+  postType,
+  id,
+  role = 'ROLE_STAFF',
+}: PostFooterProps) {
   const nextPost =
     post.nextId && post.nextTitle ? { id: post.nextId, title: post.nextTitle } : null;
   const prevPost =
@@ -36,7 +44,7 @@ export default function PostFooter({ post, margin = '', postType, id }: PostFoot
       {nextPost && <Row post={nextPost} type="next" postType={postType} />}
       {prevPost && <Row post={prevPost} type="prev" postType={postType} />}
       <div className="mt-16 flex justify-end">
-        <LoginVisible staff>
+        <LoginVisible role={role}>
           {id && (
             <>
               <PostDeleteButton postType={postType} id={id} />

--- a/app/[locale]/community/council/report/[id]/edit/client.tsx
+++ b/app/[locale]/community/council/report/[id]/edit/client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { postCouncilReportAction } from '@/actions/council';
+import { putCouncilReportAction } from '@/actions/council';
 import CouncilReportEditor, {
   CouncilReportEditorContent,
 } from '@/app/[locale]/community/council/report/components/CouncilReportEditor';
@@ -13,23 +13,25 @@ import { getPath } from '@/utils/page';
 const councilReportListPath = getPath(councilReportList);
 
 export default function CouncilReportEditPageContent({
+  id,
   defaultValues,
 }: {
+  id: number;
   defaultValues: CouncilReportEditorContent;
 }) {
   const router = useRouter();
 
   const onCancel = () => {
-    router.push(councilReportListPath);
+    router.push(`${councilReportListPath}/${id}`);
   };
 
   const onSubmit = async ({ mainImage: image, ...requestObject }: CouncilReportEditorContent) => {
-    const formData = contentToFormData('CREATE', { requestObject, image });
-    await postCouncilReportAction(formData);
+    const formData = contentToFormData('EDIT', { requestObject, image });
+    await putCouncilReportAction(id, formData);
   };
 
   return (
-    <PageLayout title="활동 보고 작성" titleType="big" titleMargin="mb-[2.75rem]" hideNavbar>
+    <PageLayout title="활동 보고 수정" titleType="big" titleMargin="mb-[2.75rem]" hideNavbar>
       <CouncilReportEditor onCancel={onCancel} onSubmit={onSubmit} defaultValues={defaultValues} />
     </PageLayout>
   );

--- a/app/[locale]/community/council/report/[id]/edit/client.tsx
+++ b/app/[locale]/community/council/report/[id]/edit/client.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { postCouncilReportAction } from '@/actions/council';
+import CouncilReportEditor, {
+  CouncilReportEditorContent,
+} from '@/app/[locale]/community/council/report/components/CouncilReportEditor';
+import PageLayout from '@/components/layout/pageLayout/PageLayout';
+import { councilReportList } from '@/constants/segmentNode';
+import { useRouter } from '@/i18n/routing';
+import { contentToFormData } from '@/utils/formData';
+import { getPath } from '@/utils/page';
+
+const councilReportListPath = getPath(councilReportList);
+
+export default function CouncilReportEditPageContent({
+  defaultValues,
+}: {
+  defaultValues: CouncilReportEditorContent;
+}) {
+  const router = useRouter();
+
+  const onCancel = () => {
+    router.push(councilReportListPath);
+  };
+
+  const onSubmit = async ({ mainImage: image, ...requestObject }: CouncilReportEditorContent) => {
+    const formData = contentToFormData('CREATE', { requestObject, image });
+    await postCouncilReportAction(formData);
+  };
+
+  return (
+    <PageLayout title="활동 보고 작성" titleType="big" titleMargin="mb-[2.75rem]" hideNavbar>
+      <CouncilReportEditor onCancel={onCancel} onSubmit={onSubmit} defaultValues={defaultValues} />
+    </PageLayout>
+  );
+}

--- a/app/[locale]/community/council/report/[id]/edit/page.tsx
+++ b/app/[locale]/community/council/report/[id]/edit/page.tsx
@@ -1,0 +1,3 @@
+export default async function CouncilReportEditPage() {
+  return 'asd';
+}

--- a/app/[locale]/community/council/report/[id]/edit/page.tsx
+++ b/app/[locale]/community/council/report/[id]/edit/page.tsx
@@ -11,10 +11,11 @@ export default async function CouncilReportEditPage({
   if (isNaN(parsedId)) throw new Error(`잘못된 아이디: ${id}`);
 
   const report = await getCouncilReport(parsedId);
-  console.log(report);
+
   return (
     <CouncilReportEditPageContent
-      defaultValues={{ ...report, mainImage: { type: 'UPLOADED_IMAGE', url: '' } }}
+      id={parsedId}
+      defaultValues={{ ...report, mainImage: { type: 'UPLOADED_IMAGE', url: report.imageURL } }}
     />
   );
 }

--- a/app/[locale]/community/council/report/[id]/edit/page.tsx
+++ b/app/[locale]/community/council/report/[id]/edit/page.tsx
@@ -1,3 +1,20 @@
-export default async function CouncilReportEditPage() {
-  return 'asd';
+import { getCouncilReport } from '@/apis/v2/council/report/[id]';
+import CouncilReportEditPageContent from '@/app/[locale]/community/council/report/[id]/edit/client';
+
+export default async function CouncilReportEditPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const parsedId = parseInt(id);
+  if (isNaN(parsedId)) throw new Error(`잘못된 아이디: ${id}`);
+
+  const report = await getCouncilReport(parsedId);
+  console.log(report);
+  return (
+    <CouncilReportEditPageContent
+      defaultValues={{ ...report, mainImage: { type: 'UPLOADED_IMAGE', url: '' } }}
+    />
+  );
 }

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -3,7 +3,7 @@ import 'dayjs/locale/ko';
 import dayjs from 'dayjs';
 import { getTranslations } from 'next-intl/server';
 
-import { CouncilReport } from '@/apis/types/council';
+import { getCouncilReport } from '@/apis/v2/council/report/[id]';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import { StraightNode } from '@/components/common/Nodes';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
@@ -12,27 +12,13 @@ import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { councilReportList } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
 
-const council: CouncilReport = {
-  id: 2,
-  title: 'title',
-  description: 'description',
-  sequence: 1,
-  name: 'name',
-  createdAt: '2022-01-01T00:00:00.000Z',
-  prevId: 1,
-  prevTitle: 'prevTitle',
-  nextId: 3,
-  nextTitle: 'nextTitle',
-};
-
 interface Props {
   params: Promise<{ id: number; locale: string }>;
 }
 
 export async function generateMetadata({ params }: Props) {
-  const { locale } = await params;
-  // const { title } = await getCouncilReport(id);
-  const { title } = council;
+  const { locale, id } = await params;
+  const { title } = await getCouncilReport(id);
 
   return await getMetadata({
     locale,
@@ -44,8 +30,7 @@ export async function generateMetadata({ params }: Props) {
 export default async function CouncilReportPage({ params }: Props) {
   const { id, locale } = await params;
   const t = await getTranslations({ locale });
-
-  // const council = await getCouncilReport(id);
+  const council = await getCouncilReport(id);
 
   const { title, description, sequence, name, createdAt } = council;
   const author = `제${sequence}대 학생회 ${name}`;

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -28,8 +28,8 @@ export async function generateMetadata({ params }: Props) {
 }
 
 export default async function CouncilReportPage({ params }: Props) {
-  const { id, locale } = await params;
-  const t = await getTranslations({ locale });
+  const { id } = await params;
+  const t = await getTranslations('Content');
   const council = await getCouncilReport(id);
 
   const { title, description, sequence, name, createdAt } = council;
@@ -55,7 +55,13 @@ export default async function CouncilReportPage({ params }: Props) {
       >
         <HTMLViewer htmlContent={description} wrapperClassName="mb-10" />
         <StraightNode />
-        <PostFooter post={council} postType="council/report" id={id.toString()} margin="mt-12" />
+        <PostFooter
+          post={council}
+          postType="council/report"
+          id={id.toString()}
+          margin="mt-12"
+          role="ROLE_COUNCIL"
+        />
       </div>
     </PageLayout>
   );

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -60,7 +60,7 @@ export default async function CouncilReportPage({ params }: Props) {
           postType="council/report"
           id={id.toString()}
           margin="mt-12"
-          role="ROLE_COUNCIL"
+          role={['ROLE_COUNCIL', 'ROLE_STAFF']}
         />
       </div>
     </PageLayout>

--- a/app/[locale]/community/council/report/components/CouncilReportEditor.tsx
+++ b/app/[locale]/community/council/report/components/CouncilReportEditor.tsx
@@ -15,10 +15,11 @@ export interface CouncilReportEditorContent {
 interface Props {
   onCancel: () => void;
   onSubmit: (content: CouncilReportEditorContent) => Promise<void>;
+  defaultValues?: CouncilReportEditorContent;
 }
 
-export default function CouncilReportEditor({ onCancel, onSubmit }: Props) {
-  const methods = useForm<CouncilReportEditorContent>();
+export default function CouncilReportEditor({ onCancel, onSubmit, defaultValues }: Props) {
+  const methods = useForm<CouncilReportEditorContent>({ defaultValues });
   const { handleSubmit } = methods;
 
   return (

--- a/app/[locale]/community/council/report/page.tsx
+++ b/app/[locale]/community/council/report/page.tsx
@@ -24,7 +24,7 @@ export default async function CouncilReportList() {
           <Tile key={report.id} {...report} />
         ))}
       </div>
-      <LoginVisible>
+      <LoginVisible role="ROLE_COUNCIL">
         <div className="mt-[40px] flex justify-end">
           <Link href={`${path}/create`}>
             <button

--- a/app/[locale]/community/council/report/page.tsx
+++ b/app/[locale]/community/council/report/page.tsx
@@ -24,7 +24,7 @@ export default async function CouncilReportList() {
           <Tile key={report.id} {...report} />
         ))}
       </div>
-      <LoginVisible role="ROLE_COUNCIL">
+      <LoginVisible role={['ROLE_COUNCIL', 'ROLE_STAFF']}>
         <div className="mt-[40px] flex justify-end">
           <Link href={`${path}/create`}>
             <button

--- a/app/[locale]/people/staff/[id]/page.tsx
+++ b/app/[locale]/people/staff/[id]/page.tsx
@@ -33,7 +33,6 @@ export default async function StaffMemberPage(props: StaffMemberPageProps) {
   try {
     const id = parseInt(params.id);
     const data = await getStaff(id);
-    console.log(data);
 
     return (
       <StaffMemberPageContent

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import createMiddleware from 'next-intl/middleware';
 
+import { Role } from '@/apis/types/role';
 import { isProd } from '@/constants/env';
 import { routing } from '@/i18n/routing';
 
@@ -9,9 +10,15 @@ import { BASE_URL, LOGIN_URL } from './constants/network';
 
 const handleI18nRouting = createMiddleware(routing);
 
-const isAuthRequired = (pathname: string) => {
+// TODO: 페이지별 권한관리가 개판이라서 정리 한 번 해줘야 함
+const isAuthRequired = (pathname: string): Role | undefined => {
   if (pathname.startsWith('/en')) pathname = pathname.slice(3);
-  return pathname.startsWith('/admin') || pathname.endsWith('create') || pathname.endsWith('edit');
+  if (pathname.startsWith('/admin') || pathname.endsWith('create')) return 'ROLE_STAFF';
+
+  if (pathname.endsWith('edit')) {
+    if (pathname.includes('council')) return 'ROLE_COUNCIL';
+    else return 'ROLE_STAFF';
+  }
 };
 
 const isCouncilRequired = (pathname: string) => {


### PR DESCRIPTION
## 작업 요약

활동보고 편집 관련 api, server action, 에디터 컴포넌트 구현

## 상세 내용

활동보고 페이지가 추가되면서 PostFooter 컴포넌트도 수정이 필요했는데, 바람직한 상황이라고는 생각되지 않아 https://github.com/wafflestudio/csereal-web/issues/322 에서 리팩터링해보겠습니닷.

학생회 권한관련 사항을 middleware에 반영합니다. 

## 테스트 방법

학생회 권한 로그인 후 편집/삭제 기능이 동작하는지 확인

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
