### PR TITLE
🐛 학생회칙, 활동보고 QA 반영

### DIFF
--- a/app/[locale]/community/council/report/components/CouncilReportEditor.tsx
+++ b/app/[locale]/community/council/report/components/CouncilReportEditor.tsx
@@ -48,7 +48,6 @@ export default function CouncilReportEditor({ onCancel, onSubmit, defaultValues 
             <Form.Text
               name="sequence"
               maxWidth="w-[39px]"
-              placeholder="39"
               options={{ required: true }}
               type="number"
               className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"

--- a/app/[locale]/community/council/report/page.tsx
+++ b/app/[locale]/community/council/report/page.tsx
@@ -44,18 +44,21 @@ const Tile = ({ id, title, sequence, name, createdAt, imageURL }: CouncilReport)
   const href = `${path}/${id}`;
   const dateStr = dayjs(createdAt).format('YYYY/MM/DD');
 
+  const tileSize = 212;
+  const tileSizeTailwind = 'h-[212px] w-[212px]';
+
   return (
-    <Link className="group relative block h-[232px] w-[232px]" href={href}>
+    <Link className={`group relative block ${tileSizeTailwind}`} href={href}>
       <Image
         src={imageURL}
         alt=""
-        className="h-[232px] w-[232px] object-cover"
-        width={232}
-        height={232}
+        className={`${tileSizeTailwind} object-cover`}
+        width={tileSize}
+        height={tileSize}
       />
       <div className="absolute bottom-0 left-0 right-0 top-0 flex flex-col justify-between border border-neutral-200 bg-neutral-100 px-[12px] py-[16px] opacity-0 transition-opacity group-hover:opacity-100">
-        <h3 className="text-[20px] font-semibold text-neutral-950">{title}</h3>
-        <div className="text-xs font-normal text-neutral-500">
+        <h3 className="text-lg font-semibold text-neutral-950">{title}</h3>
+        <div className="text-sm font-normal text-neutral-500">
           <p>
             제 {sequence}대 학생회 {name}
           </p>

--- a/app/[locale]/community/council/rules/page.tsx
+++ b/app/[locale]/community/council/rules/page.tsx
@@ -30,13 +30,13 @@ export default async function CouncilIntroPage() {
         </div>
       </LoginVisible>
 
-      <h3 className="mb-[20px] text-[20px] font-semibold text-neutral-950">학생회칙</h3>
+      <h3 className="mb-[20px] text-lg font-semibold text-neutral-950">학생회칙</h3>
 
       {resp.constitution.attachments.map((attachment) => (
         <CouncilAttachment key={attachment.id} {...attachment} />
       ))}
 
-      <h3 className="mb-[20px] mt-[40px] text-[20px] font-semibold text-neutral-950">세칙</h3>
+      <h3 className="mb-[20px] mt-[40px] text-lg font-semibold text-neutral-950">세칙</h3>
 
       {resp.bylaw.attachments.map((attachment) => (
         <CouncilAttachment key={attachment.id} {...attachment} />


### PR DESCRIPTION
## 작업 요약

- 학생회칙 및 세칙 페이지 소제목 (학생회칙, 세칙) 폰트 크기 20->18
- 활동 보고 페이지 맥북 13인치에선 3열로 보이는데 4열로 보이도록 대응 - 활동 보고 페이지 각 썸네일 호버 시 문구 타이틀 20->18, 학생회 및 날짜 12->13으로 수정
- 활동 보고 페이지 새 게시물 작성 시 게시자에 제 n대 학생회~~ 쓰는 란 placeholder 제거

## 상세 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
