### PR TITLE
🐛 게시물 내 HTML 내용 중 이미지 비율 깨짐 문제 수정

### DIFF
--- a/components/form/html/HTMLViewer.tsx
+++ b/components/form/html/HTMLViewer.tsx
@@ -53,7 +53,7 @@ export default function HTMLViewer({
       {topRightContent?.type === 'component' && (
         <div className="relative float-right">{topRightContent.content}</div>
       )}
-      <div className={`sun-editor-editable ${contentClassName} `}>
+      <div className={`sun-editor-editable ${contentClassName}`}>
         {parse(linkedHTML, { replace })}
         <HTMLHydrator />
       </div>

--- a/components/form/html/HTMLViewer.tsx
+++ b/components/form/html/HTMLViewer.tsx
@@ -32,16 +32,11 @@ export default function HTMLViewer({
 
   const replace = (domNode: DOMNode) => {
     if (domNode instanceof Element && domNode.attribs) {
+      const { style, ...rest } = domNode.attribs;
+      domNode.attribs = rest;
+      domNode.attribs['data-style'] = style;
       if (domNode.name === 'img') {
-        const imgStyle = 'height:auto;';
-        const { style, ...rest } = domNode.attribs;
-        const combinedStyle = style ? `${style}; ${imgStyle}` : imgStyle;
-        domNode.attribs = rest;
-        domNode.attribs['data-style'] = combinedStyle;
-      } else {
-        const { style, ...rest } = domNode.attribs;
-        domNode.attribs = rest;
-        domNode.attribs['data-style'] = style;
+        domNode.attribs['data-style'] += ' height:auto;';
       }
     }
     return domNode;

--- a/components/form/html/HTMLViewer.tsx
+++ b/components/form/html/HTMLViewer.tsx
@@ -33,7 +33,7 @@ export default function HTMLViewer({
   const replace = (domNode: DOMNode) => {
     if (domNode instanceof Element && domNode.attribs) {
       if (domNode.name === 'img') {
-        const imgStyle = 'max-width:100%; height:auto;';
+        const imgStyle = 'height:auto;';
         const { style, ...rest } = domNode.attribs;
         const combinedStyle = style ? `${style}; ${imgStyle}` : imgStyle;
         domNode.attribs = rest;

--- a/components/form/html/HTMLViewer.tsx
+++ b/components/form/html/HTMLViewer.tsx
@@ -32,9 +32,17 @@ export default function HTMLViewer({
 
   const replace = (domNode: DOMNode) => {
     if (domNode instanceof Element && domNode.attribs) {
-      const { style, ...rest } = domNode.attribs;
-      domNode.attribs = rest;
-      domNode.attribs['data-style'] = style;
+      if (domNode.name === 'img') {
+        const imgStyle = 'max-width:100%; height:auto;';
+        const { style, ...rest } = domNode.attribs;
+        const combinedStyle = style ? `${style}; ${imgStyle}` : imgStyle;
+        domNode.attribs = rest;
+        domNode.attribs['data-style'] = combinedStyle;
+      } else {
+        const { style, ...rest } = domNode.attribs;
+        domNode.attribs = rest;
+        domNode.attribs['data-style'] = style;
+      }
     }
     return domNode;
   };
@@ -45,7 +53,7 @@ export default function HTMLViewer({
       {topRightContent?.type === 'component' && (
         <div className="relative float-right">{topRightContent.content}</div>
       )}
-      <div className={`sun-editor-editable ${contentClassName}`}>
+      <div className={`sun-editor-editable ${contentClassName} `}>
         {parse(linkedHTML, { replace })}
         <HTMLHydrator />
       </div>


### PR DESCRIPTION
## 작업 요약

게시물 내에서 이미지가 레이아웃 크기에 반응하지 않는 문제 수정

## 상세 내용

./components/form/html/HTMLViewer.tsx 에서 HTML 내용을 파싱할 때 쓰이는 replace 함수를 수정.  
img 태그일 경우 style 속성에   
max-width:100%; height:auto;   -> max-width 스타일은 굳이 없어도 되어서 제거했습니다.
을 추가합니다.

## 테스트 방법



## 참고 문서


