### PR TITLE
🐛 회의록 qa 반영

### DIFF
--- a/app/[locale]/academics/components/timeline/Timeline.tsx
+++ b/app/[locale]/academics/components/timeline/Timeline.tsx
@@ -2,9 +2,15 @@ interface TimelineProps {
   times: number[];
   selectedTime: number;
   setSelectedTime: (year: number) => void;
+  hideDownArrow?: boolean;
 }
 
-export default function Timeline({ times, selectedTime, setSelectedTime }: TimelineProps) {
+export default function Timeline({
+  times,
+  selectedTime,
+  setSelectedTime,
+  hideDownArrow,
+}: TimelineProps) {
   return (
     <div className="relative flex w-full max-w-4xl flex-wrap">
       {times.map((time, i) => (
@@ -12,7 +18,7 @@ export default function Timeline({ times, selectedTime, setSelectedTime }: Timel
           time={time}
           isSelected={time === selectedTime}
           onChange={() => setSelectedTime(time)}
-          isLast={i === times.length - 1}
+          isLast={!hideDownArrow && i === times.length - 1}
           key={time}
         />
       ))}

--- a/app/[locale]/academics/components/timeline/TimelineViewer.tsx
+++ b/app/[locale]/academics/components/timeline/TimelineViewer.tsx
@@ -12,7 +12,7 @@ import { Link, usePathname } from '@/i18n/routing';
 import { refreshPage } from '@/utils/refreshPage';
 import { CustomError, handleServerResponse } from '@/utils/serverActionError';
 
-import Timeline from './Timeline';
+import Timeline from '../../../../../components/common/Timeline';
 
 interface TimelineViewerProps<T> {
   contents: T[];

--- a/app/[locale]/community/council/meeting-minute/CouncilMeetingMinuteEditor.tsx
+++ b/app/[locale]/community/council/meeting-minute/CouncilMeetingMinuteEditor.tsx
@@ -6,6 +6,7 @@ import Fieldset from '@/components/form/Fieldset';
 import Form from '@/components/form/Form';
 import { EditorFile } from '@/types/form';
 import { handleServerResponse } from '@/utils/serverActionError';
+import { errorToast } from '@/utils/toast';
 
 export type MinuteFormData = { year: number; file: EditorFile[] };
 
@@ -29,6 +30,10 @@ export default function CouncilMeetingMinuteEditor({
   const { handleSubmit } = formMethods;
 
   const onSubmit = async (requestObject: MinuteFormData) => {
+    if (requestObject.file.length === 0) {
+      errorToast('파일을 선택해주세요.');
+      return;
+    }
     const resp = await _onSubmit(requestObject);
     handleServerResponse(resp, { successMessage: '저장되었습니다.' });
   };

--- a/app/[locale]/community/council/meeting-minute/CouncilMeetingMinuteEditor.tsx
+++ b/app/[locale]/community/council/meeting-minute/CouncilMeetingMinuteEditor.tsx
@@ -8,7 +8,7 @@ import { EditorFile } from '@/types/form';
 import { handleServerResponse } from '@/utils/serverActionError';
 import { errorToast } from '@/utils/toast';
 
-export type MinuteFormData = { year: number; file: EditorFile[] };
+export type MinuteFormData = { year: number; index: number; file: EditorFile[] };
 
 interface Props {
   defaultValues?: MinuteFormData;
@@ -24,6 +24,7 @@ export default function CouncilMeetingMinuteEditor({
   const formMethods = useForm<MinuteFormData>({
     defaultValues: defaultValues ?? {
       year: new Date().getFullYear() + 1,
+      index: 1,
       file: [],
     },
   });
@@ -41,14 +42,16 @@ export default function CouncilMeetingMinuteEditor({
   return (
     <FormProvider {...formMethods}>
       <Form>
-        <Fieldset title="연도" mb="mb-6" titleMb="mb-2">
-          <Form.Text
-            name="year"
-            maxWidth="w-[55px]"
-            disabled={defaultValues !== undefined}
-            options={{ required: true, valueAsNumber: true }}
-          />
-        </Fieldset>
+        {!defaultValues && (
+          <Fieldset title="연도" mb="mb-6" titleMb="mb-2">
+            <Form.Text
+              name="year"
+              maxWidth="w-[55px]"
+              disabled={defaultValues !== undefined}
+              options={{ required: true, valueAsNumber: true }}
+            />
+          </Fieldset>
+        )}
         <Fieldset.File>
           <Form.File name="file" />
         </Fieldset.File>

--- a/app/[locale]/community/council/meeting-minute/MinutePageContent.tsx
+++ b/app/[locale]/community/council/meeting-minute/MinutePageContent.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 
 import { deleteMinuteAction } from '@/actions/council';
 import { CouncilMeetingMinute } from '@/apis/types/council';
-import Timeline from '@/app/[locale]/academics/components/timeline/Timeline';
 import { DeleteButton, EditButton } from '@/components/common/Buttons';
 import LoginVisible from '@/components/common/LoginVisible';
+import Timeline from '@/components/common/Timeline';
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { councilMinute } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
@@ -36,7 +36,7 @@ export default function MinutePageContent({
         times={timeLineYears}
         selectedTime={selectedYear}
         setSelectedTime={setSelectedYear}
-        hideDownArrow
+        showDownArrow={false}
       />
       <MinuteAddButton year={selectedYear} newIndex={selectedContents[0].index + 1} />
       <div className="divide-y divide-neutral-200">

--- a/app/[locale]/community/council/meeting-minute/MinutePageContent.tsx
+++ b/app/[locale]/community/council/meeting-minute/MinutePageContent.tsx
@@ -16,18 +16,17 @@ import { handleServerResponse } from '@/utils/serverActionError';
 import CouncilAttachment from '../components/CouncilAttachments';
 
 const minutePath = getPath(councilMinute);
-const THIS_YEAR = new Date().getFullYear();
 
 export default function MinutePageContent({
   contents,
 }: {
   contents: { [year: string]: CouncilMeetingMinute[] };
 }) {
-  const [selectedYear, setSelectedYear] = useState(THIS_YEAR);
+  const [selectedYear, setSelectedYear] = useState(Number(Object.keys(contents)[0]));
   const timeLineYears = Object.keys(contents)
     .map(Number)
     .sort((a, b) => b - a);
-  const selectedContents = contents[selectedYear.toString()] ?? [];
+  const selectedContents = contents[selectedYear] ?? [];
 
   return (
     <PageLayout titleType="big">

--- a/app/[locale]/community/council/meeting-minute/MinutePageContent.tsx
+++ b/app/[locale]/community/council/meeting-minute/MinutePageContent.tsx
@@ -22,7 +22,8 @@ export default function MinutePageContent({
 }: {
   contents: { [year: string]: CouncilMeetingMinute[] };
 }) {
-  const [selectedYear, setSelectedYear] = useState(Number(Object.keys(contents)[0]));
+  const latestYear = Math.max(...Object.keys(contents).map(Number));
+  const [selectedYear, setSelectedYear] = useState(latestYear);
   const timeLineYears = Object.keys(contents)
     .map(Number)
     .sort((a, b) => b - a);
@@ -35,8 +36,9 @@ export default function MinutePageContent({
         times={timeLineYears}
         selectedTime={selectedYear}
         setSelectedTime={setSelectedYear}
+        hideDownArrow
       />
-      <MinuteAddButton year={selectedYear} />
+      <MinuteAddButton year={selectedYear} newIndex={selectedContents[0].index + 1} />
       <div className="divide-y divide-neutral-200">
         {selectedContents.map((minute, i) => {
           return (
@@ -48,11 +50,11 @@ export default function MinutePageContent({
   );
 }
 
-function MinuteAddButton({ year }: { year: number }) {
+function MinuteAddButton({ year, newIndex }: { year: number; newIndex: number }) {
   return (
     <LoginVisible role={['ROLE_COUNCIL', 'ROLE_STAFF']}>
       <Link
-        href={`${minutePath}/create?year=${year}`}
+        href={`${minutePath}/create?year=${year}&index=${newIndex}`}
         className="mt-3 flex w-[220px] items-center gap-1.5 rounded-sm border border-main-orange px-2 py-2.5 text-main-orange duration-200 hover:bg-main-orange hover:text-white"
       >
         <span className="material-symbols-outlined font-light">add</span>

--- a/app/[locale]/community/council/meeting-minute/MinutePageContent.tsx
+++ b/app/[locale]/community/council/meeting-minute/MinutePageContent.tsx
@@ -26,7 +26,7 @@ export default function MinutePageContent({
   const timeLineYears = Object.keys(contents)
     .map(Number)
     .sort((a, b) => b - a);
-  const selectedContents = contents[selectedYear] ?? [];
+  const selectedContents = contents[selectedYear].sort((a, b) => b.index - a.index) ?? [];
 
   return (
     <PageLayout titleType="big">
@@ -36,18 +36,14 @@ export default function MinutePageContent({
         selectedTime={selectedYear}
         setSelectedTime={setSelectedYear}
       />
-      <div className="mt-7">
+      <MinuteAddButton year={selectedYear} />
+      <div className="divide-y divide-neutral-200">
         {selectedContents.map((minute, i) => {
           return (
-            <Minutes
-              minute={minute}
-              key={`${minute.year}_${minute.index}`}
-              isLast={i === selectedContents.length - 1}
-            />
+            <Minutes minute={minute} key={`${minute.year}_${minute.index}`} isLatest={i === 0} />
           );
         })}
       </div>
-      <MinuteAddButton year={selectedYear} />
     </PageLayout>
   );
 }
@@ -80,7 +76,7 @@ function YearAddButton() {
   );
 }
 
-function Minutes({ minute, isLast }: { minute: CouncilMeetingMinute; isLast: boolean }) {
+function Minutes({ minute, isLatest }: { minute: CouncilMeetingMinute; isLatest: boolean }) {
   const handleDelete = async () => {
     const resp = await deleteMinuteAction(minute.year, minute.index);
     handleServerResponse(resp, {
@@ -89,12 +85,12 @@ function Minutes({ minute, isLast }: { minute: CouncilMeetingMinute; isLast: boo
   };
 
   return (
-    <div className="mb-10 w-full border-b border-neutral-200 pb-10">
-      <div className="flex items-center justify-between gap-2.5 ">
+    <div className="mb-10 w-full pt-10">
+      <div className="flex items-center justify-between gap-2.5">
         <div className="font-semibold">{minute.index}차 회의 회의록</div>
         <LoginVisible role={['ROLE_COUNCIL', 'ROLE_STAFF']}>
           <div className="flex justify-end gap-3">
-            {isLast && <DeleteButton onDelete={handleDelete} />}
+            {isLatest && <DeleteButton onDelete={handleDelete} />}
             <EditButton href={`${minutePath}/edit?year=${minute.year}&index=${minute.index}`} />
           </div>
         </LoginVisible>

--- a/app/[locale]/community/council/meeting-minute/create/client.tsx
+++ b/app/[locale]/community/council/meeting-minute/create/client.tsx
@@ -11,7 +11,13 @@ import CouncilMeetingMinuteEditor, { MinuteFormData } from '../CouncilMeetingMin
 
 const minutePath = getPath(councilMinute);
 
-export default function CouncilMinuteCreateClientPage({ year }: { year: number }) {
+export default function CouncilMinuteCreateClientPage({
+  year,
+  index,
+}: {
+  year: number;
+  index: number;
+}) {
   const router = useRouter();
 
   const onCancel = () => router.push(minutePath);
@@ -23,9 +29,13 @@ export default function CouncilMinuteCreateClientPage({ year }: { year: number }
 
   return (
     // TODO: 영문 번역
-    <PageLayout title={`${year ? `${year}년 ` : ''}학생회 회의록 추가`} titleType="big" hideNavbar>
+    <PageLayout
+      title={`${year ? `${year}년 ` : ''}학생회${index ? ` ${index}차` : ''} 회의록 추가`}
+      titleType="big"
+      hideNavbar
+    >
       <CouncilMeetingMinuteEditor
-        defaultValues={year ? { year, file: [] } : undefined}
+        defaultValues={year ? { year, index, file: [] } : undefined}
         onSubmit={onSubmit}
         onCancel={onCancel}
       />

--- a/app/[locale]/community/council/meeting-minute/create/page.tsx
+++ b/app/[locale]/community/council/meeting-minute/create/page.tsx
@@ -10,7 +10,7 @@ export default async function CouncilMinuteCreatePage({
   const { year } = await searchParams;
   const yearInNumber = Number(year);
 
-  if (yearInNumber !== undefined && Number.isNaN(yearInNumber))
+  if (year !== undefined && yearInNumber !== undefined && Number.isNaN(yearInNumber))
     throw new Error('/meeting-minute?year=[year]: year가 숫자가 아닙니다.');
 
   return <CouncilMinuteCreateClientPage year={yearInNumber} />;

--- a/app/[locale]/community/council/meeting-minute/create/page.tsx
+++ b/app/[locale]/community/council/meeting-minute/create/page.tsx
@@ -5,13 +5,16 @@ import CouncilMinuteCreateClientPage from '@/app/[locale]/community/council/meet
 export default async function CouncilMinuteCreatePage({
   searchParams,
 }: {
-  searchParams: Promise<{ year?: string }>;
+  searchParams: Promise<{ year?: string; index?: string }>;
 }) {
-  const { year } = await searchParams;
+  const { year, index } = await searchParams;
   const yearInNumber = Number(year);
+  const indexInNumber = Number(index);
 
   if (year !== undefined && yearInNumber !== undefined && Number.isNaN(yearInNumber))
     throw new Error('/meeting-minute?year=[year]: year가 숫자가 아닙니다.');
+  if (index !== undefined && indexInNumber !== undefined && Number.isNaN(indexInNumber))
+    throw new Error('/meeting-minute?index=[index]: index가 숫자가 아닙니다.');
 
-  return <CouncilMinuteCreateClientPage year={yearInNumber} />;
+  return <CouncilMinuteCreateClientPage year={yearInNumber} index={indexInNumber} />;
 }

--- a/app/[locale]/community/council/meeting-minute/edit/EditMinutePageContent.tsx
+++ b/app/[locale]/community/council/meeting-minute/edit/EditMinutePageContent.tsx
@@ -39,7 +39,7 @@ export default function EditMinutePageContent({
     // TODO: 영문 번역
     <PageLayout title={`${year}년 학생회 ${index}차 회의록 편집`} titleType="big" hideNavbar>
       <CouncilMeetingMinuteEditor
-        defaultValues={{ year, file: getEditorFile(data.attachments) }}
+        defaultValues={{ year, index, file: getEditorFile(data.attachments) }}
         onSubmit={onSubmit}
         onCancel={onCancel}
       />

--- a/components/common/Timeline.tsx
+++ b/components/common/Timeline.tsx
@@ -2,14 +2,14 @@ interface TimelineProps {
   times: number[];
   selectedTime: number;
   setSelectedTime: (year: number) => void;
-  hideDownArrow?: boolean;
+  showDownArrow?: boolean;
 }
 
 export default function Timeline({
   times,
   selectedTime,
   setSelectedTime,
-  hideDownArrow,
+  showDownArrow = true,
 }: TimelineProps) {
   return (
     <div className="relative flex w-full max-w-4xl flex-wrap">
@@ -18,7 +18,7 @@ export default function Timeline({
           time={time}
           isSelected={time === selectedTime}
           onChange={() => setSelectedTime(time)}
-          isLast={!hideDownArrow && i === times.length - 1}
+          showDownArrow={showDownArrow && i === times.length - 1}
           key={time}
         />
       ))}
@@ -30,10 +30,10 @@ interface TimeSpotProps {
   time: number;
   isSelected: boolean;
   onChange: () => void;
-  isLast?: boolean;
+  showDownArrow?: boolean;
 }
 
-function TimeSpot({ time, isSelected, onChange, isLast }: TimeSpotProps) {
+function TimeSpot({ time, isSelected, onChange, showDownArrow }: TimeSpotProps) {
   return (
     <label
       className={`group relative mb-7 mr-11 flex h-[38px] items-center ${
@@ -44,7 +44,7 @@ function TimeSpot({ time, isSelected, onChange, isLast }: TimeSpotProps) {
         <Circle highlight={isSelected} />
         <span className="flex items-center text-sm tracking-[0.02em] text-main-orange">
           {time}
-          {isLast && (
+          {showDownArrow && (
             <span className="material-symbols-rounded text-base font-light">arrow_downward</span>
           )}
         </span>


### PR DESCRIPTION
## 작업 요약

- 연도 추가 안 되던 것 수정
- 회의록 추가/편집 시 첨부파일 필수로 지정
- 회의록 차수 내림차순 정렬, 추가 버튼 위로 이동
- 특정 연도 하위에 회의록 추가 시 연도와 차수는 이미 정해져 있으므로 페이지 제목에 넣고, 에디터 본문에서는 첨부파일만 편집
- 타임라인 마지막 down arrow 제거 

## 상세 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
