### PR TITLE
🐛 학생회탭 서브내비 처리

### DIFF
--- a/app/[locale]/community/council/client.tsx
+++ b/app/[locale]/community/council/client.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Header from '@/components/layout/header/Header';
+import CategoryGrid from '@/components/layout/pageLayout/CategoryGrid';
+import PageTitle from '@/components/layout/pageLayout/PageTitle';
+import { council } from '@/constants/segmentNode';
+
+export default function CouncilClientPage() {
+  return (
+    <div className="bg-neutral-850">
+      <Header />
+      <PageTitle
+        title={council.name}
+        currentPage={council}
+        titleType="big"
+        margin="mb-6 sm:mb-11"
+      />
+      <CategoryGrid currentPage={council} theme="light" />
+    </div>
+  );
+}

--- a/app/[locale]/community/council/page.tsx
+++ b/app/[locale]/community/council/page.tsx
@@ -1,8 +1,7 @@
-import Header from '@/components/layout/header/Header';
-import CategoryGrid from '@/components/layout/pageLayout/CategoryGrid';
-import PageTitle from '@/components/layout/pageLayout/PageTitle';
 import { council } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+
+import CouncilClientPage from './client';
 
 export async function generateMetadata(props: { params: Promise<{ locale: string }> }) {
   const params = await props.params;
@@ -13,16 +12,5 @@ export async function generateMetadata(props: { params: Promise<{ locale: string
 }
 
 export default async function CouncilPage() {
-  return (
-    <div className="bg-neutral-850">
-      <Header />
-      <PageTitle
-        title={council.name}
-        currentPage={council}
-        titleType="big"
-        margin="mb-6 sm:mb-11"
-      />
-      <CategoryGrid currentPage={council} theme="light" />
-    </div>
-  );
+  return <CouncilClientPage />;
 }

--- a/components/layout/pageLayout/SubNavbar.tsx
+++ b/components/layout/pageLayout/SubNavbar.tsx
@@ -2,7 +2,7 @@ import { useTranslations } from 'next-intl';
 
 import { CurvedVerticalNode } from '@/components/common/Nodes';
 import NavLabel from '@/components/layout/navbar/NavLabel';
-import { council, SegmentNode } from '@/constants/segmentNode';
+import { SegmentNode } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
 import useStyle from '@/utils/hooks/useStyle';
 import { getAllSubTabs, getDepth, getPath, getRootTab } from '@/utils/page';
@@ -14,10 +14,7 @@ export default function SubNavbar({ currentTab }: { currentTab: SegmentNode }) {
   const t = useTranslations('Nav');
   const rootTab = getRootTab(currentTab);
   // 학생회 페이지에 있을 경우에만 학생회 하위 탭들 표시, 다른 페이지에서는 숨김
-  const subTabs =
-    currentTab.parent === council
-      ? getAllSubTabs(rootTab)
-      : getAllSubTabs(rootTab).filter((tab) => tab.parent !== council);
+  const subTabs = getAllSubTabs(rootTab).filter((tab) => !tab.hideInSubNav?.(currentTab));
 
   const height = `${(subTabs.length + 1) * ITEM_HEIGHT}px`;
 

--- a/components/layout/pageLayout/SubNavbar.tsx
+++ b/components/layout/pageLayout/SubNavbar.tsx
@@ -13,7 +13,6 @@ const INDENTATION = 16;
 export default function SubNavbar({ currentTab }: { currentTab: SegmentNode }) {
   const t = useTranslations('Nav');
   const rootTab = getRootTab(currentTab);
-  // 학생회 페이지에 있을 경우에만 학생회 하위 탭들 표시, 다른 페이지에서는 숨김
   const subTabs = getAllSubTabs(rootTab).filter((tab) => !tab.hideInSubNav?.(currentTab));
 
   const height = `${(subTabs.length + 1) * ITEM_HEIGHT}px`;

--- a/components/layout/pageLayout/SubNavbar.tsx
+++ b/components/layout/pageLayout/SubNavbar.tsx
@@ -2,25 +2,22 @@ import { useTranslations } from 'next-intl';
 
 import { CurvedVerticalNode } from '@/components/common/Nodes';
 import NavLabel from '@/components/layout/navbar/NavLabel';
-import { SegmentNode } from '@/constants/segmentNode';
+import { council, SegmentNode } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
 import useStyle from '@/utils/hooks/useStyle';
 import { getAllSubTabs, getDepth, getPath, getRootTab } from '@/utils/page';
 
-type TreeNode = {
-  name: string;
-  segment: string;
-  isPage: boolean;
-  children: TreeNode[];
-};
-
 const ITEM_HEIGHT = 33;
 const INDENTATION = 16;
 
-export default function SubNavbar({ currentTab }: { currentTab: TreeNode }) {
+export default function SubNavbar({ currentTab }: { currentTab: SegmentNode }) {
   const t = useTranslations('Nav');
-  const rootTab = getRootTab(currentTab as SegmentNode);
-  const subTabs = getAllSubTabs(rootTab);
+  const rootTab = getRootTab(currentTab);
+  // 학생회 페이지에 있을 경우에만 학생회 하위 탭들 표시, 다른 페이지에서는 숨김
+  const subTabs =
+    currentTab.parent === council
+      ? getAllSubTabs(rootTab)
+      : getAllSubTabs(rootTab).filter((tab) => tab.parent !== council);
 
   const height = `${(subTabs.length + 1) * ITEM_HEIGHT}px`;
 

--- a/constants/segmentNode.ts
+++ b/constants/segmentNode.ts
@@ -722,5 +722,3 @@ export const tentenProposal: SegmentNode = {
 
 // 기존 홈페이지 푸터 링크가 propsal로 이동시는 등 proposal 내용이 우선순위라 판단되어 기존과 다르게 0번째로 배치
 tentenProject.children = [tentenProposal, tentenManager, tentenParticipants];
-console.log('Council children:', council.children);
-console.log('Community children:', community.children);

--- a/constants/segmentNode.ts
+++ b/constants/segmentNode.ts
@@ -4,8 +4,8 @@ export interface SegmentNode {
   isPage: boolean;
   children: SegmentNode[];
   parent: SegmentNode | null;
-
   hideInNavbar?: boolean;
+  hideInSubNav?: (currentPage: SegmentNode) => boolean;
 }
 
 export const main: SegmentNode = {
@@ -143,6 +143,7 @@ export const councilIntro: SegmentNode = {
   parent: council,
   children: [],
   hideInNavbar: true,
+  hideInSubNav: (currentPage) => currentPage.parent !== council,
 };
 
 export const councilMinute: SegmentNode = {
@@ -152,6 +153,7 @@ export const councilMinute: SegmentNode = {
   parent: council,
   children: [],
   hideInNavbar: true,
+  hideInSubNav: (currentPage) => currentPage.parent !== council,
 };
 
 export const councilBylaws: SegmentNode = {
@@ -161,6 +163,7 @@ export const councilBylaws: SegmentNode = {
   parent: council,
   children: [],
   hideInNavbar: true,
+  hideInSubNav: (currentTab) => currentTab.parent !== council,
 };
 
 export const councilReportList: SegmentNode = {
@@ -170,6 +173,7 @@ export const councilReportList: SegmentNode = {
   parent: council,
   children: [],
   hideInNavbar: true,
+  hideInSubNav: (currentPage) => currentPage.parent !== council,
 };
 
 export const people: SegmentNode = {

--- a/constants/segmentNode.ts
+++ b/constants/segmentNode.ts
@@ -5,7 +5,7 @@ export interface SegmentNode {
   children: SegmentNode[];
   parent: SegmentNode | null;
   hideInNavbar?: boolean;
-  hideInSubNav?: (currentPage: SegmentNode) => boolean;
+  hideInSubNav?(currentTab: SegmentNode): boolean;
 }
 
 export const main: SegmentNode = {
@@ -143,7 +143,7 @@ export const councilIntro: SegmentNode = {
   parent: council,
   children: [],
   hideInNavbar: true,
-  hideInSubNav: (currentPage) => currentPage.parent !== council,
+  hideInSubNav: (currentTab) => currentTab?.parent !== council,
 };
 
 export const councilMinute: SegmentNode = {
@@ -153,7 +153,7 @@ export const councilMinute: SegmentNode = {
   parent: council,
   children: [],
   hideInNavbar: true,
-  hideInSubNav: (currentPage) => currentPage.parent !== council,
+  hideInSubNav: (currentTab) => currentTab?.parent !== council,
 };
 
 export const councilBylaws: SegmentNode = {
@@ -163,7 +163,7 @@ export const councilBylaws: SegmentNode = {
   parent: council,
   children: [],
   hideInNavbar: true,
-  hideInSubNav: (currentTab) => currentTab.parent !== council,
+  hideInSubNav: (currentTab) => currentTab?.parent !== council,
 };
 
 export const councilReportList: SegmentNode = {
@@ -173,7 +173,7 @@ export const councilReportList: SegmentNode = {
   parent: council,
   children: [],
   hideInNavbar: true,
-  hideInSubNav: (currentPage) => currentPage.parent !== council,
+  hideInSubNav: (currentTab) => currentTab?.parent !== council,
 };
 
 export const people: SegmentNode = {
@@ -722,3 +722,5 @@ export const tentenProposal: SegmentNode = {
 
 // 기존 홈페이지 푸터 링크가 propsal로 이동시는 등 proposal 내용이 우선순위라 판단되어 기존과 다르게 0번째로 배치
 tentenProject.children = [tentenProposal, tentenManager, tentenParticipants];
+console.log('Council children:', council.children);
+console.log('Community children:', community.children);


### PR DESCRIPTION
## 작업 요약

- 학생회 관련 페이지에 있을 때만 학생회 하위탭들 전부 서브내비에 표시
- 소식 내 다른 페이지에서는 `학생회`탭만 표시
- `TreeNode` 불필요한 것 같아 `SegmentNode`로 대체


## 상세 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
#328 