### PR TITLE
🐛 학생회 하위탭 내브바에서 하이라이트 표시 안 됨 고침

### DIFF
--- a/components/layout/navbar/NavbarDetail.tsx
+++ b/components/layout/navbar/NavbarDetail.tsx
@@ -31,7 +31,7 @@ function NavTree({ node, curNode, depth = 0 }: NavTreeProps) {
       {depth !== 0 && (
         <NavTreeLabel
           segmentNode={node}
-          highlight={curNode === node}
+          highlight={curNode === node || curNode.parent === node}
           containerClassName={depth === 0 ? 'mb-[1.75rem]' : 'mb-[1.5rem]'}
           anchorClassName="text-md"
         />

--- a/components/layout/navbar/NavbarDetail.tsx
+++ b/components/layout/navbar/NavbarDetail.tsx
@@ -1,4 +1,4 @@
-import { SegmentNode } from '@/constants/segmentNode';
+import { council, SegmentNode } from '@/constants/segmentNode';
 import { useNavbarContext } from '@/contexts/NavbarContext';
 import useCurrentSegmentNode from '@/utils/hooks/useCurrentSegmentNode';
 
@@ -31,7 +31,7 @@ function NavTree({ node, curNode, depth = 0 }: NavTreeProps) {
       {depth !== 0 && (
         <NavTreeLabel
           segmentNode={node}
-          highlight={curNode === node || curNode.parent === node}
+          highlight={curNode === node || (curNode.parent === council && curNode.parent === node)}
           containerClassName={depth === 0 ? 'mb-[1.75rem]' : 'mb-[1.5rem]'}
           anchorClassName="text-md"
         />


### PR DESCRIPTION
## 작업 요약

학생회 하위 탭에서 Navbar에 highlight 정상적으로 표시

## 상세 내용

```
highlight={curNode === node || curNode.parent === node}
```
로 고쳤습니다.

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
