### PR TITLE
♻️ postfooter에서 posttype props제거

### DIFF
--- a/apis/types/council.ts
+++ b/apis/types/council.ts
@@ -13,9 +13,9 @@ export interface CouncilReport {
   sequence: number;
   name: string;
   createdAt: string;
-  prevId: number;
-  prevTitle: string;
-  nextId: number;
-  nextTitle: string;
+  prevId: number | null;
+  prevTitle: string | null;
+  nextId: number | null;
+  nextTitle: string | null;
   imageURL: string;
 }

--- a/app/[locale]/community/components/PostDeleteButton.tsx
+++ b/app/[locale]/community/components/PostDeleteButton.tsx
@@ -2,10 +2,6 @@
 
 import { useTransition } from 'react';
 
-import { deleteCouncilReportAction } from '@/actions/council';
-import { deleteNewsAction } from '@/actions/news';
-import { deleteNoticeAction } from '@/actions/notice';
-import { deleteSeminarAction } from '@/actions/seminar';
 import AlertModal from '@/components/modal/AlertModal';
 import useModal from '@/utils/hooks/useModal';
 import { errorToast, successToast } from '@/utils/toast';
@@ -34,17 +30,6 @@ export default function PostDeleteButton({
       } else {
         successToast('게시글을 삭제했습니다.');
       }
-
-      // 만약 deleteAction 자체를 Props로 받게 되면 굳이 action 검증 단계를 넣지 않아도 될 것 같은데... 맞을까요?
-      // const action = deleteAction;
-      // if (action) {
-      //   const result = await action(idInNumber);
-      //   if (result) {
-      //     errorToast(result.message);
-      //   } else {
-      //     successToast('게시글을 삭제했습니다.');
-      //   }
-      // }
     });
   };
 

--- a/app/[locale]/community/components/PostDeleteButton.tsx
+++ b/app/[locale]/community/components/PostDeleteButton.tsx
@@ -10,7 +10,13 @@ import AlertModal from '@/components/modal/AlertModal';
 import useModal from '@/utils/hooks/useModal';
 import { errorToast, successToast } from '@/utils/toast';
 
-export default function PostDeleteButton({ postType, id }: { postType: string; id: string }) {
+export default function PostDeleteButton({
+  id,
+  deleteAction,
+}: {
+  id: string;
+  deleteAction: (id: number) => Promise<{ message: string } | undefined>;
+}) {
   const { openModal } = useModal();
   const [, startTransition] = useTransition();
 
@@ -20,30 +26,25 @@ export default function PostDeleteButton({ postType, id }: { postType: string; i
     return;
   }
 
-  const postTypeToAction = (postType: string) => {
-    switch (postType) {
-      case 'notice':
-        return deleteNoticeAction;
-      case 'news':
-        return deleteNewsAction;
-      case 'seminar':
-        return deleteSeminarAction;
-      case 'council/report':
-        return deleteCouncilReportAction;
-    }
-  };
-
   const handleDelete = async () => {
     startTransition(async () => {
-      const action = postTypeToAction(postType);
-      if (action) {
-        const result = await action(idInNumber);
-        if (result) {
-          errorToast(result.message);
-        } else {
-          successToast('게시글을 삭제했습니다.');
-        }
+      const result = await deleteAction(idInNumber);
+      if (result) {
+        errorToast(result.message);
+      } else {
+        successToast('게시글을 삭제했습니다.');
       }
+
+      // 만약 deleteAction 자체를 Props로 받게 되면 굳이 action 검증 단계를 넣지 않아도 될 것 같은데... 맞을까요?
+      // const action = deleteAction;
+      // if (action) {
+      //   const result = await action(idInNumber);
+      //   if (result) {
+      //     errorToast(result.message);
+      //   } else {
+      //     successToast('게시글을 삭제했습니다.');
+      //   }
+      // }
     });
   };
 

--- a/app/[locale]/community/components/PostFooter.tsx
+++ b/app/[locale]/community/components/PostFooter.tsx
@@ -10,10 +10,12 @@ import PostDeleteButton from './PostDeleteButton';
 type PostFooterProps = {
   path: string;
   id?: string;
-  nextId?: number;
-  nextTitle?: string;
-  prevId?: number;
-  prevTitle?: string;
+  post: {
+    nextId: number | null;
+    nextTitle: string | null;
+    prevId: number | null;
+    prevTitle: string | null;
+  };
   margin?: string;
   role?: Role[] | Role;
   deleteAction: (id: number) => Promise<{ message: string } | undefined>;
@@ -30,15 +32,14 @@ export default function PostFooter({
   path,
   margin = '',
   id,
-  nextId,
-  nextTitle,
-  prevId,
-  prevTitle,
+  post,
   role = 'ROLE_STAFF',
   deleteAction,
 }: PostFooterProps) {
-  const nextPost = nextId && nextTitle ? { id: nextId, title: nextTitle } : null;
-  const prevPost = prevId && prevTitle ? { id: prevId, title: prevTitle } : null;
+  const nextPost =
+    post.nextId && post.nextTitle ? { id: post.nextId, title: post.nextTitle } : null;
+  const prevPost =
+    post.prevId && post.prevTitle ? { id: post.prevId, title: post.prevTitle } : null;
 
   return (
     <div className={`flex flex-col ${margin}`}>

--- a/app/[locale]/community/components/PostFooter.tsx
+++ b/app/[locale]/community/components/PostFooter.tsx
@@ -12,11 +12,12 @@ import PaginatedLink from './PaginatedLink';
 import PostDeleteButton from './PostDeleteButton';
 
 type PostFooterProps = {
-  postType: PostType;
   post: Notice | News | Seminar | CouncilReport;
+  path: string;
   id?: string;
   margin?: string;
   role?: Role[] | Role;
+  deleteAction: (id: number) => Promise<{ message: string } | undefined>;
 };
 
 type AdjPost = {
@@ -24,15 +25,15 @@ type AdjPost = {
   title: string;
 };
 
-type PostType = 'notice' | 'seminar' | 'news' | 'council/report';
 type RowType = 'next' | 'prev';
 
 export default function PostFooter({
   post,
+  path,
   margin = '',
-  postType,
   id,
   role = 'ROLE_STAFF',
+  deleteAction,
 }: PostFooterProps) {
   const nextPost =
     post.nextId && post.nextTitle ? { id: post.nextId, title: post.nextTitle } : null;
@@ -41,29 +42,26 @@ export default function PostFooter({
 
   return (
     <div className={`flex flex-col ${margin}`}>
-      {nextPost && <Row post={nextPost} type="next" postType={postType} />}
-      {prevPost && <Row post={prevPost} type="prev" postType={postType} />}
+      {nextPost && <Row post={nextPost} type="next" path={path} />}
+      {prevPost && <Row post={prevPost} type="prev" path={path} />}
       <div className="mt-16 flex justify-end">
         <LoginVisible role={role}>
           {id && (
             <>
-              <PostDeleteButton postType={postType} id={id} />
-              <PostEditLink href={`/community/${postType}/${id}/edit`} />
+              <PostDeleteButton deleteAction={deleteAction} id={id} />
+              <PostEditLink href={`${path}/${id}/edit`} />
             </>
           )}
         </LoginVisible>
-        <PostListLink href={`/community/${postType}`} />
+        <PostListLink href={`${path}`} />
       </div>
     </div>
   );
 }
 
-function Row({ post, type, postType }: { post: AdjPost; type: RowType; postType: PostType }) {
+function Row({ post, type, path }: { post: AdjPost; type: RowType; path: string }) {
   return (
-    <Link
-      className="group mb-[2px] flex w-fit items-center"
-      href={`/community/${postType}/${post.id}`}
-    >
+    <Link className="group mb-[2px] flex w-fit items-center" href={`${path}/${post.id}`}>
       <RowIcon type={type} />
       <RowDescription type={type} />
       <RowPostTitle title={post.title} />
@@ -93,7 +91,7 @@ function RowPostTitle({ title }: { title?: string }) {
   return (
     <p
       className={`
-      ${title ? 'group-hover:underline' : ''} 
+      ${title ? 'group-hover:underline' : ''}
       line-clamp-1 text-md font-normal
       `}
     >

--- a/app/[locale]/community/components/PostFooter.tsx
+++ b/app/[locale]/community/components/PostFooter.tsx
@@ -1,10 +1,6 @@
 import { useTranslations } from 'next-intl';
 
-import { CouncilReport } from '@/apis/types/council';
-import { News } from '@/apis/types/news';
-import { Notice } from '@/apis/types/notice';
 import { Role } from '@/apis/types/role';
-import { Seminar } from '@/apis/types/seminar';
 import LoginVisible from '@/components/common/LoginVisible';
 import { Link } from '@/i18n/routing';
 
@@ -12,9 +8,12 @@ import PaginatedLink from './PaginatedLink';
 import PostDeleteButton from './PostDeleteButton';
 
 type PostFooterProps = {
-  post: Notice | News | Seminar | CouncilReport;
   path: string;
   id?: string;
+  nextId?: number;
+  nextTitle?: string;
+  prevId?: number;
+  prevTitle?: string;
   margin?: string;
   role?: Role[] | Role;
   deleteAction: (id: number) => Promise<{ message: string } | undefined>;
@@ -28,17 +27,18 @@ type AdjPost = {
 type RowType = 'next' | 'prev';
 
 export default function PostFooter({
-  post,
   path,
   margin = '',
   id,
+  nextId,
+  nextTitle,
+  prevId,
+  prevTitle,
   role = 'ROLE_STAFF',
   deleteAction,
 }: PostFooterProps) {
-  const nextPost =
-    post.nextId && post.nextTitle ? { id: post.nextId, title: post.nextTitle } : null;
-  const prevPost =
-    post.prevId && post.prevTitle ? { id: post.prevId, title: post.prevTitle } : null;
+  const nextPost = nextId && nextTitle ? { id: nextId, title: nextTitle } : null;
+  const prevPost = prevId && prevTitle ? { id: prevId, title: prevTitle } : null;
 
   return (
     <div className={`flex flex-col ${margin}`}>

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -58,10 +58,7 @@ export default async function CouncilReportPage({ params }: Props) {
         <HTMLViewer htmlContent={description} wrapperClassName="mb-10" />
         <StraightNode />
         <PostFooter
-          nextId={council.nextId ?? undefined}
-          nextTitle={council.nextTitle ?? undefined}
-          prevId={council.prevId ?? undefined}
-          prevTitle={council.prevTitle ?? undefined}
+          post={council}
           path={getPath(councilReportList)}
           id={id.toString()}
           margin="mt-12"

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -3,6 +3,7 @@ import 'dayjs/locale/ko';
 import dayjs from 'dayjs';
 import { getTranslations } from 'next-intl/server';
 
+import { deleteCouncilReportAction } from '@/actions/council';
 import { getCouncilReport } from '@/apis/v2/council/report/[id]';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import { StraightNode } from '@/components/common/Nodes';
@@ -57,10 +58,11 @@ export default async function CouncilReportPage({ params }: Props) {
         <StraightNode />
         <PostFooter
           post={council}
-          postType="council/report"
+          path="/community/council/report"
           id={id.toString()}
           margin="mt-12"
           role={['ROLE_COUNCIL', 'ROLE_STAFF']}
+          deleteAction={deleteCouncilReportAction}
         />
       </div>
     </PageLayout>

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -12,6 +12,7 @@ import { PAGE_PADDING_BOTTOM_TAILWIND } from '@/components/layout/pageLayout/pad
 import PageLayout from '@/components/layout/pageLayout/PageLayout';
 import { councilReportList } from '@/constants/segmentNode';
 import { getMetadata } from '@/utils/metadata';
+import { getPath } from '@/utils/page';
 
 interface Props {
   params: Promise<{ id: number; locale: string }>;
@@ -58,7 +59,7 @@ export default async function CouncilReportPage({ params }: Props) {
         <StraightNode />
         <PostFooter
           post={council}
-          path="/community/council/report"
+          path={getPath(councilReportList)}
           id={id.toString()}
           margin="mt-12"
           role={['ROLE_COUNCIL', 'ROLE_STAFF']}

--- a/app/[locale]/community/council/report/[id]/page.tsx
+++ b/app/[locale]/community/council/report/[id]/page.tsx
@@ -58,7 +58,10 @@ export default async function CouncilReportPage({ params }: Props) {
         <HTMLViewer htmlContent={description} wrapperClassName="mb-10" />
         <StraightNode />
         <PostFooter
-          post={council}
+          nextId={council.nextId ?? undefined}
+          nextTitle={council.nextTitle ?? undefined}
+          prevId={council.prevId ?? undefined}
+          prevTitle={council.prevTitle ?? undefined}
           path={getPath(councilReportList)}
           id={id.toString()}
           margin="mt-12"

--- a/app/[locale]/community/news/[id]/NewsViewer.tsx
+++ b/app/[locale]/community/news/[id]/NewsViewer.tsx
@@ -1,6 +1,7 @@
 // TODO: searchParams를 사용했음에도 static rendering이 되는 것 같아 추가
 export const dynamic = 'force-dynamic';
 
+import { deleteNewsAction } from '@/actions/news';
 import { News } from '@/apis/types/news';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import Attachments from '@/components/common/Attachments';
@@ -37,7 +38,13 @@ export default async function NewsViewer({ news }: NewsPostPageProps) {
         />
         <StraightNode />
         <Tags tags={news.tags} margin="mt-3 ml-6" searchPath={newsPath} />
-        <PostFooter post={news} postType="news" id={news.id.toString()} margin="mt-12" />
+        <PostFooter
+          post={news}
+          id={news.id.toString()}
+          deleteAction={deleteNewsAction}
+          margin="mt-12"
+          path={newsPath}
+        />
       </div>
     </>
   );

--- a/app/[locale]/community/news/[id]/NewsViewer.tsx
+++ b/app/[locale]/community/news/[id]/NewsViewer.tsx
@@ -39,7 +39,10 @@ export default async function NewsViewer({ news }: NewsPostPageProps) {
         <StraightNode />
         <Tags tags={news.tags} margin="mt-3 ml-6" searchPath={newsPath} />
         <PostFooter
-          post={news}
+          nextId={news.nextId ?? undefined}
+          nextTitle={news.nextTitle ?? undefined}
+          prevId={news.prevId ?? undefined}
+          prevTitle={news.prevTitle ?? undefined}
           id={news.id.toString()}
           deleteAction={deleteNewsAction}
           margin="mt-12"

--- a/app/[locale]/community/news/[id]/NewsViewer.tsx
+++ b/app/[locale]/community/news/[id]/NewsViewer.tsx
@@ -39,10 +39,7 @@ export default async function NewsViewer({ news }: NewsPostPageProps) {
         <StraightNode />
         <Tags tags={news.tags} margin="mt-3 ml-6" searchPath={newsPath} />
         <PostFooter
-          nextId={news.nextId ?? undefined}
-          nextTitle={news.nextTitle ?? undefined}
-          prevId={news.prevId ?? undefined}
-          prevTitle={news.prevTitle ?? undefined}
+          post={news}
           id={news.id.toString()}
           deleteAction={deleteNewsAction}
           margin="mt-12"

--- a/app/[locale]/community/notice/[id]/NoticeViewer.tsx
+++ b/app/[locale]/community/notice/[id]/NoticeViewer.tsx
@@ -30,7 +30,10 @@ export default async function NoticeViewer({ notice }: NoticePostPageProps) {
         <StraightNode />
         <Tags tags={notice.tags} margin="mt-3 ml-6" searchPath={noticePath} />
         <PostFooter
-          post={notice}
+          nextId={notice.nextId ?? undefined}
+          nextTitle={notice.nextTitle ?? undefined}
+          prevId={notice.prevId ?? undefined}
+          prevTitle={notice.prevTitle ?? undefined}
           path={noticePath}
           id={notice.id.toString()}
           margin="mt-12"

--- a/app/[locale]/community/notice/[id]/NoticeViewer.tsx
+++ b/app/[locale]/community/notice/[id]/NoticeViewer.tsx
@@ -30,10 +30,7 @@ export default async function NoticeViewer({ notice }: NoticePostPageProps) {
         <StraightNode />
         <Tags tags={notice.tags} margin="mt-3 ml-6" searchPath={noticePath} />
         <PostFooter
-          nextId={notice.nextId ?? undefined}
-          nextTitle={notice.nextTitle ?? undefined}
-          prevId={notice.prevId ?? undefined}
-          prevTitle={notice.prevTitle ?? undefined}
+          post={notice}
           path={noticePath}
           id={notice.id.toString()}
           margin="mt-12"

--- a/app/[locale]/community/notice/[id]/NoticeViewer.tsx
+++ b/app/[locale]/community/notice/[id]/NoticeViewer.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from 'next-intl';
 
+import { deleteNoticeAction } from '@/actions/notice';
 import { Notice } from '@/apis/types/notice';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import Attachments from '@/components/common/Attachments';
@@ -28,7 +29,13 @@ export default async function NoticeViewer({ notice }: NoticePostPageProps) {
         <HTMLViewer htmlContent={notice.description} wrapperClassName="mb-10" />
         <StraightNode />
         <Tags tags={notice.tags} margin="mt-3 ml-6" searchPath={noticePath} />
-        <PostFooter post={notice} postType="notice" id={notice.id.toString()} margin="mt-12" />
+        <PostFooter
+          post={notice}
+          path={noticePath}
+          id={notice.id.toString()}
+          margin="mt-12"
+          deleteAction={deleteNoticeAction}
+        />
       </div>
     </>
   );

--- a/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
+++ b/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
 
+import { deleteSeminarAction } from '@/actions/seminar';
 import { Seminar } from '@/apis/types/seminar';
 import PostFooter from '@/app/[locale]/community/components/PostFooter';
 import Attachments from '@/components/common/Attachments';
@@ -71,7 +72,13 @@ export default async function SeminarViewer({ seminar }: SeminarPostPageProps) {
         )}
 
         <StraightNode margin="mt-10" />
-        <PostFooter post={seminar} postType="seminar" id={seminar.id.toString()} margin="mt-12" />
+        <PostFooter
+          post={seminar}
+          path="/community/seminar"
+          id={seminar.id.toString()}
+          margin="mt-12"
+          deleteAction={deleteSeminarAction}
+        />
       </div>
     </>
   );

--- a/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
+++ b/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
@@ -9,73 +9,75 @@ import ImageWithFallback from '@/components/common/ImageWithFallback';
 import { StraightNode } from '@/components/common/Nodes';
 import HTMLViewer from '@/components/form/html/HTMLViewer';
 import { PAGE_PADDING_BOTTOM_TAILWIND } from '@/components/layout/pageLayout/paddings';
+import { seminar } from '@/constants/segmentNode';
 import { Link } from '@/i18n/routing';
+import { getPath } from '@/utils/page';
 
 interface SeminarPostPageProps {
-  seminar: Seminar;
+  seminarData: Seminar;
 }
 
-export default async function SeminarViewer({ seminar }: SeminarPostPageProps) {
+export default async function SeminarViewer({ seminarData }: SeminarPostPageProps) {
   const t = await getTranslations('Content');
 
   return (
     <>
       <h2 className="px-5 py-9 text-[1.25rem] font-semibold leading-[1.4] sm:pl-[100px] sm:pr-[340px]">
-        {seminar.title}
+        {seminarData.title}
       </h2>
       <div
         className={`bg-neutral-50 px-5 pt-9 sm:pl-[100px] sm:pr-[340px] ${PAGE_PADDING_BOTTOM_TAILWIND}`}
       >
-        {seminar.attachments.length !== 0 && <Attachments files={seminar.attachments} />}
+        {seminarData.attachments.length !== 0 && <Attachments files={seminarData.attachments} />}
         <div className="mb-9 flex flex-col-reverse justify-between gap-5 text-md sm:flex-row">
           <div className="flex flex-col gap-3">
             <div>
-              {t('이름')}: <LinkOrText href={seminar.speakerURL}>{seminar.name}</LinkOrText>
+              {t('이름')}: <LinkOrText href={seminarData.speakerURL}>{seminarData.name}</LinkOrText>
             </div>
-            <div>{seminar.speakerTitle && <p>직함: {seminar.speakerTitle}</p>}</div>
+            <div>{seminarData.speakerTitle && <p>직함: {seminarData.speakerTitle}</p>}</div>
             <div>
               {t('소속')}:{' '}
-              <LinkOrText href={seminar.affiliationURL}>{seminar.affiliation}</LinkOrText>
+              <LinkOrText href={seminarData.affiliationURL}>{seminarData.affiliation}</LinkOrText>
             </div>
             <div className="mt-10">
-              {t('주최')}: {seminar.host}
+              {t('주최')}: {seminarData.host}
             </div>
             <div>
-              {t('날짜')}: {formatStartEndDate(seminar.startDate, seminar.endDate)}
+              {t('날짜')}: {formatStartEndDate(seminarData.startDate, seminarData.endDate)}
             </div>
             <div>
-              {t('위치')}: {seminar.location}
+              {t('위치')}: {seminarData.location}
             </div>
           </div>
           <div className="relative mx-7 aspect-square sm:h-60 sm:w-60">
             <ImageWithFallback
               alt={`대표_이미지`}
-              src={seminar.imageURL}
+              src={seminarData.imageURL}
               className="object-contain"
               fill
             />
           </div>
         </div>
 
-        {seminar.description && (
+        {seminarData.description && (
           <>
             <div className="mt-10 font-bold">{t('요약')}</div>
-            <HTMLViewer htmlContent={seminar.description} />
+            <HTMLViewer htmlContent={seminarData.description} />
           </>
         )}
 
-        {seminar.introduction && (
+        {seminarData.introduction && (
           <>
             <div className="mt-10 font-bold">{t('연사 소개')}</div>
-            <HTMLViewer htmlContent={seminar.introduction} />
+            <HTMLViewer htmlContent={seminarData.introduction} />
           </>
         )}
 
         <StraightNode margin="mt-10" />
         <PostFooter
-          post={seminar}
-          path="/community/seminar"
-          id={seminar.id.toString()}
+          post={seminarData}
+          path={getPath(seminar)}
+          id={seminarData.id.toString()}
           margin="mt-12"
           deleteAction={deleteSeminarAction}
         />

--- a/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
+++ b/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
@@ -75,10 +75,7 @@ export default async function SeminarViewer({ seminarData }: SeminarPostPageProp
 
         <StraightNode margin="mt-10" />
         <PostFooter
-          nextId={seminarData.nextId ?? undefined}
-          nextTitle={seminarData.nextTitle ?? undefined}
-          prevId={seminarData.prevId ?? undefined}
-          prevTitle={seminarData.prevTitle ?? undefined}
+          post={seminarData}
           path={getPath(seminar)}
           id={seminarData.id.toString()}
           margin="mt-12"

--- a/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
+++ b/app/[locale]/community/seminar/[id]/SeminarViewer.tsx
@@ -75,7 +75,10 @@ export default async function SeminarViewer({ seminarData }: SeminarPostPageProp
 
         <StraightNode margin="mt-10" />
         <PostFooter
-          post={seminarData}
+          nextId={seminarData.nextId ?? undefined}
+          nextTitle={seminarData.nextTitle ?? undefined}
+          prevId={seminarData.prevId ?? undefined}
+          prevTitle={seminarData.prevTitle ?? undefined}
           path={getPath(seminar)}
           id={seminarData.id.toString()}
           margin="mt-12"

--- a/app/[locale]/community/seminar/[id]/page.tsx
+++ b/app/[locale]/community/seminar/[id]/page.tsx
@@ -43,12 +43,12 @@ export default async function SeminarPostPage(props: SeminarPostPageProps) {
   if (Number.isNaN(id)) throw new Error('/seminar/[id]: id가 숫자가 아닙니다.');
 
   try {
-    const seminar = await getSeminarPost(id, searchParams);
+    const seminarData = await getSeminarPost(id, searchParams);
 
     return (
       <PageLayout titleType="big" removePadding>
         <Suspense fallback={<PostFallback />}>
-          <SeminarViewer seminar={seminar} />
+          <SeminarViewer seminarData={seminarData} />
         </Suspense>
       </PageLayout>
     );


### PR DESCRIPTION
## 작업 요약

https://github.com/wafflestudio/csereal-web/issues/322 에 적힌 이슈를 처리했습니다.

## 상세 내용

postType을 없애고, 각 상위 컴포넌트에서 해당하는 서버 액션과 경로를 직접 props로 보내서 postFooter에서 처리합니다.

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
