### PR TITLE
🐛 internal cancel 버튼의 리다이렉트 경로 앞에 / 추가

### DIFF
--- a/app/.internal/components/InternalEditor.tsx
+++ b/app/.internal/components/InternalEditor.tsx
@@ -24,7 +24,7 @@ export default function InternalEditor({
   const { handleSubmit } = formMethods;
 
   const router = useRouter();
-  const onCancel = () => router.push('.internal');
+  const onCancel = () => router.push('/.internal');
 
   const onSubmit = async ({ description }: FormData) => {
     try {


### PR DESCRIPTION
## 작업 요약

internal edit 에서 취소 버튼을 누르면 /.internal/.internal 로 이동되던 걸 수정했습니다.

## 상세 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
