### PR TITLE
🐛 에디터 작성 취소 버튼 눌렀을 때, 모달창 속 확인 버튼을 디폴트 포커스 값으로 지정

### DIFF
--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -110,7 +110,7 @@ export function EditButton({ href }: { href: string }) {
 
 export const ConfirmButton = ({
   title,
-  buttonRef,
+  ref,
   onClick,
 }: {
   title: string;
@@ -127,7 +127,7 @@ export const ConfirmButton = ({
       disabled={pending}
       type="submit"
       onClick={onClick}
-      ref={buttonRef}
+      ref={ref}
     >
       {title}
     </button>

--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -115,7 +115,7 @@ export const ConfirmButton = ({
 }: {
   title: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
-  buttonRef?: React.RefObject<HTMLButtonElement | null>;
+  ref?: React.RefObject<HTMLButtonElement | null>;
 }) => {
   const { pending } = useFormStatus();
 

--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { MouseEventHandler } from 'react';
+import { useFormStatus } from 'react-dom';
 
 import { Link } from '@/i18n/routing';
 import useModal from '@/utils/hooks/useModal';
@@ -104,3 +107,29 @@ export function EditButton({ href }: { href: string }) {
     </Link>
   );
 }
+
+export const ConfirmButton = ({
+  title,
+  buttonRef,
+  onClick,
+}: {
+  title: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  buttonRef?: React.RefObject<HTMLButtonElement | null>;
+}) => {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      className={`ml-2.5 h-[2.1875rem] rounded-[.0625rem] bg-neutral-700 px-[.875rem] py-[.3125rem] text-md font-medium leading-[1.5rem] text-white hover:bg-neutral-500 ${
+        pending && 'opacity-30'
+      }`}
+      disabled={pending}
+      type="submit"
+      onClick={onClick}
+      ref={buttonRef}
+    >
+      {title}
+    </button>
+  );
+};

--- a/components/form/Calendar.tsx
+++ b/components/form/Calendar.tsx
@@ -1,9 +1,8 @@
 import { useController } from 'react-hook-form';
 
 import ReactCalendar from '@/components/common/MuiDateSelector';
+import ModalFrame from '@/components/modal/ModalFrame';
 import useModal from '@/utils/hooks/useModal';
-
-import ModalFrame from '../modal/ModalFrame';
 
 interface Props {
   name: string;

--- a/components/form/Calendar.tsx
+++ b/components/form/Calendar.tsx
@@ -1,8 +1,9 @@
 import { useController } from 'react-hook-form';
 
 import ReactCalendar from '@/components/common/MuiDateSelector';
-import ModalFrame from '@/components/modal/ModalFrame';
 import useModal from '@/utils/hooks/useModal';
+
+import ModalFrame from '../modal/ModalFrame';
 
 interface Props {
   name: string;

--- a/components/modal/AlertModal.tsx
+++ b/components/modal/AlertModal.tsx
@@ -47,7 +47,7 @@ export default function AlertModal({
               closeModal();
             }}
           />
-          <ConfirmButton title={confirmText} buttonRef={confirmButtonRef} />
+          <ConfirmButton title={confirmText} ref={confirmButtonRef} />
         </div>
       </form>
     </ModalFrame>

--- a/components/modal/AlertModal.tsx
+++ b/components/modal/AlertModal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useFormStatus } from 'react-dom';
+import { useEffect, useRef } from 'react';
 
+import { ConfirmButton, GrayButton } from '@/components/common/Buttons';
 import useModal from '@/utils/hooks/useModal';
 
-import { GrayButton } from '../common/Buttons';
 import ModalFrame from './ModalFrame';
 
 interface AlertModalProps {
@@ -23,6 +23,11 @@ export default function AlertModal({
   onConfirm,
 }: AlertModalProps) {
   const { closeModal } = useModal();
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    confirmButtonRef.current?.focus();
+  }, []);
 
   return (
     <ModalFrame onClose={closeModal}>
@@ -42,7 +47,7 @@ export default function AlertModal({
               closeModal();
             }}
           />
-          <ConfirmButton text={confirmText} />
+          <ConfirmButton title={confirmText} buttonRef={confirmButtonRef} />
         </div>
       </form>
     </ModalFrame>
@@ -51,18 +56,4 @@ export default function AlertModal({
 
 function AlertMessage({ message }: { message: string }) {
   return <p className="mb-6 mt-1 text-neutral-800">{message}</p>;
-}
-
-function ConfirmButton({ text }: { text: string }) {
-  const { pending } = useFormStatus();
-
-  return (
-    <button
-      className={`ml-2.5 h-[2.1875rem] rounded-[.0625rem] bg-neutral-700 px-[17px] text-xs font-bold text-white hover:bg-neutral-500`}
-      disabled={pending}
-      type="submit"
-    >
-      {text}
-    </button>
-  );
 }


### PR DESCRIPTION
## 작업 요약

에디터 작성 취소 모달이 나타났을 때, 기본 포커스를 모달창의 확인 버튼으로 둡니다.

## 상세 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->

## 참고 문서

<!-- 참고한 문서나 코드가 리뷰에 도움된다면 여기에 추가해주세요.  -->
