### PR TITLE
🐛  세미나실 예약 페이지 중, 달력 바깥 클릭 시 달력창 종료

### DIFF
--- a/app/[locale]/admin/helper/slide/SlideList.tsx
+++ b/app/[locale]/admin/helper/slide/SlideList.tsx
@@ -2,7 +2,7 @@ import { Dispatch } from 'react';
 
 import { SlidePreview } from '@/apis/types/admin';
 
-import SlideListHeader from './SlideListHeader';
+import SlideListHeader from './SlideLIstHeader';
 import SlideListRow from './SlideListRow';
 
 interface SlideListProps {

--- a/app/[locale]/admin/helper/slide/SlideList.tsx
+++ b/app/[locale]/admin/helper/slide/SlideList.tsx
@@ -2,7 +2,7 @@ import { Dispatch } from 'react';
 
 import { SlidePreview } from '@/apis/types/admin';
 
-import SlideListHeader from './SlideLIstHeader';
+import SlideListHeader from './SlideListHeader';
 import SlideListRow from './SlideListRow';
 
 interface SlideListProps {

--- a/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/NavigateButtons.tsx
+++ b/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/NavigateButtons.tsx
@@ -120,14 +120,12 @@ const useDateQuery = () => {
 
 const useClickOutside = <T extends HTMLElement>(handler: () => void) => {
   const ref = useRef<T | null>(null);
-  const isNode = (target: EventTarget | null): target is Node => {
-    return !!target && 'nodeType' in target;
-  };
 
   useEffect(() => {
     const handleClickOutside = (ev: MouseEvent | TouchEvent) => {
       const target = ev.target;
-      if (ref.current && isNode(target) && !ref.current.contains(target)) {
+      if (!(target instanceof Node)) return;
+      if (ref.current && !ref.current.contains(target)) {
         handler();
       }
     };

--- a/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/NavigateButtons.tsx
+++ b/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/NavigateButtons.tsx
@@ -2,12 +2,11 @@
 
 import { useEffect, useReducer, useRef } from 'react';
 
+import BasicButton from '@/app/[locale]/reservations/[roomType]/[roomName]/helper/BasicButton';
+import AddReservationModal from '@/app/[locale]/reservations/[roomType]/[roomName]/helper/modals/AddReservationModal';
+import MuiDateSelector from '@/components/common/MuiDateSelector';
 import { usePathname, useRouter } from '@/i18n/routing';
 import useModal from '@/utils/hooks/useModal';
-
-import MuiDateSelector from '../../../../../../../components/common/MuiDateSelector';
-import BasicButton from '../BasicButton';
-import AddReservationModal from '../modals/AddReservationModal';
 
 // TODO: button -> Link 수정
 export function SelectDayButton({ date }: { date: Date }) {

--- a/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/NavigateButtons.tsx
+++ b/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/NavigateButtons.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useReducer } from 'react';
+import { useEffect, useReducer, useRef } from 'react';
 
 import { usePathname, useRouter } from '@/i18n/routing';
 import useModal from '@/utils/hooks/useModal';
@@ -28,6 +28,10 @@ export function SelectDayButton({ date }: { date: Date }) {
     );
   };
 
+  const calendarRef = useClickOutside<HTMLDivElement>(() => {
+    if (showCalendar) toggleCalendar();
+  });
+
   return (
     <div>
       <BasicButton
@@ -45,15 +49,17 @@ export function SelectDayButton({ date }: { date: Date }) {
       </BasicButton>
       <div className="relative">
         {showCalendar && (
-          <MuiDateSelector
-            className="absolute top-2 z-10 border border-neutral-300 bg-white"
-            date={date}
-            setDate={(date) => {
-              if (date) querySetter(date);
-              toggleCalendar();
-            }}
-            enablePast
-          />
+          <div ref={calendarRef}>
+            <MuiDateSelector
+              className="absolute top-2 z-10 border border-neutral-300 bg-white"
+              date={date}
+              setDate={(date) => {
+                if (date) querySetter(date);
+                toggleCalendar();
+              }}
+              enablePast
+            />
+          </div>
         )}
       </div>
     </div>
@@ -110,4 +116,27 @@ const useDateQuery = () => {
       .join('-');
     router.push(`${pathname}?selectedDate=${str}`, { scroll: false });
   };
+};
+
+const useClickOutside = <T extends HTMLElement>(handler: () => void) => {
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (ev: MouseEvent | TouchEvent) => {
+      const target = ev.target as Node;
+      if (ref.current && !ref.current.contains(target)) {
+        handler();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [handler]);
+
+  return ref;
 };

--- a/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/NavigateButtons.tsx
+++ b/app/[locale]/reservations/[roomType]/[roomName]/helper/calendar/NavigateButtons.tsx
@@ -120,11 +120,14 @@ const useDateQuery = () => {
 
 const useClickOutside = <T extends HTMLElement>(handler: () => void) => {
   const ref = useRef<T | null>(null);
+  const isNode = (target: EventTarget | null): target is Node => {
+    return !!target && 'nodeType' in target;
+  };
 
   useEffect(() => {
     const handleClickOutside = (ev: MouseEvent | TouchEvent) => {
-      const target = ev.target as Node;
-      if (ref.current && !ref.current.contains(target)) {
+      const target = ev.target;
+      if (ref.current && isNode(target) && !ref.current.contains(target)) {
         handler();
       }
     };


### PR DESCRIPTION
close #373 

## 작업 내용

이슈로 올라온 캘린더 바깥 클릭 시 달력 popover가 종료되도록 수정했습니다.
추가로 useClickOutside 훅은 우선 NavigationButton.tsx 안에 두었습니다. MuiCalender 외에는 이 훅을 사용할 일이 없어 보여서 따로 util로 빼지 않았는데, 더 좋은 방법이 있으면 추천해주세요~