### PR TITLE
♻️ 날짜 컨벤션 지정 및 레거시 formatDate 코드 정리

### DIFF
--- a/app/[locale]/admin/helper/ListCell.tsx
+++ b/app/[locale]/admin/helper/ListCell.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@/i18n/routing';
 import CheckboxOrange from '@/public/image/checkbox_orange.svg';
+import { useDayjs } from '@/utils/hooks/useDayjs';
 
 interface CheckboxCellProps {
   isChecked: boolean;
@@ -44,7 +45,12 @@ export function TitleCell({ title, href, width }: { title: string; href: string;
 }
 
 export function DateCell({ date, width }: { date: string; width: string }) {
-  return <span className={`${width} pl-8`}>{formatDate(new Date(date))}</span>;
+  const formatDate = useDayjs();
+  return (
+    <span className={`${width} pl-8`}>
+      {formatDate ? formatDate({ date: date, format: 'simple' }) : ''}
+    </span>
+  );
 }
 
 export function EditCell({ href, width }: { href: string; width: string }) {
@@ -59,11 +65,3 @@ export function EditCell({ href, width }: { href: string; width: string }) {
     </span>
   );
 }
-
-const formatDate = (date: Date) => {
-  const yyyy = String(date.getFullYear()).padStart(4, '0');
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-
-  return `${yyyy}/${mm}/${dd}`; // e.g. 2023/08/01
-};

--- a/app/[locale]/admin/helper/slide/SlideList.tsx
+++ b/app/[locale]/admin/helper/slide/SlideList.tsx
@@ -2,7 +2,7 @@ import { Dispatch } from 'react';
 
 import { SlidePreview } from '@/apis/types/admin';
 
-import SlideListHeader from './SlideLIstHeader';
+import SlideListHeader from './SlideListHeader';
 import SlideListRow from './SlideListRow';
 
 interface SlideListProps {

--- a/app/[locale]/community/council/report/page.tsx
+++ b/app/[locale]/community/council/report/page.tsx
@@ -61,7 +61,7 @@ const Tile = ({ id, title, sequence, name, createdAt, imageURL }: CouncilReport)
           <p>
             제 {sequence}대 학생회 {name}
           </p>
-          <p>{formatDate(createdAt).format('YYYY/MM/DD')}</p>
+          <p>{formatDate ? formatDate({ date: createdAt, format: 'simple' }) : ''}</p>
           <NaviBarClose className="absolute bottom-[16px] right-[12.5px]" />
         </div>
       </div>

--- a/app/[locale]/community/news/[id]/NewsViewer.tsx
+++ b/app/[locale]/community/news/[id]/NewsViewer.tsx
@@ -56,7 +56,7 @@ function Header({ title, date }: { title: string; date: string }) {
     <div className="flex flex-col gap-4 px-5 py-9 sm:pl-[100px] sm:pr-[340px]">
       <h2 className="text-[1.25rem] font-semibold leading-[1.4]">{title}</h2>
       <time className="text-sm font-normal tracking-wide text-neutral-500">
-        {formatDate(date).format('YYYY년 MM월 DD일 ddd요일')}
+        {formatDate ? formatDate({ date: date, format: 'day' }) : ''}
       </time>
     </div>
   );

--- a/app/[locale]/community/news/components/NewsRow.tsx
+++ b/app/[locale]/community/news/components/NewsRow.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import PaginatedLink from '@/app/[locale]/community/components/PaginatedLink';
 import ImageWithFallback from '@/components/common/ImageWithFallback';
 import Tags from '@/components/common/Tags';
 import { news } from '@/constants/segmentNode';
+import { useDayjs } from '@/utils/hooks/useDayjs';
 import { getPath } from '@/utils/page';
 
 interface NewsRowProps {
@@ -33,12 +36,7 @@ export default function NewsRow({
 }: NewsRowProps) {
   description += '...'; // clip이 안될정도로 화면이 좌우로 긴 경우 대비
 
-  const dateStr = date.toLocaleDateString('ko', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    weekday: 'long',
-  });
+  const formatDate = useDayjs();
 
   return (
     <article
@@ -47,7 +45,9 @@ export default function NewsRow({
       }`}
     >
       <div className="mr-8 flex flex-1 flex-col justify-between break-keep">
-        <time className="mb-2.5 mt-5 text-md text-neutral-800 sm:hidden">{dateStr}</time>
+        <time className="mb-2.5 mt-5 text-md text-neutral-800 sm:hidden">
+          {formatDate ? formatDate({ date: date, format: 'day' }) : ''}
+        </time>
 
         <div className="flex flex-col items-start">
           <PaginatedLink href={href} className="hover:underline">
@@ -75,7 +75,7 @@ export default function NewsRow({
         <div className="flex items-center justify-between sm:gap-2.5">
           <Tags tags={tags} searchPath={newsPath} />
           <time className="hidden self-end whitespace-nowrap text-sm leading-[26px] text-neutral-800 sm:inline">
-            {dateStr}
+            {formatDate ? formatDate({ date: date, format: 'day' }) : ''}
           </time>
         </div>
       </div>

--- a/app/[locale]/community/notice/[id]/NoticeViewer.tsx
+++ b/app/[locale]/community/notice/[id]/NoticeViewer.tsx
@@ -61,7 +61,7 @@ const Header = ({
           {t('작성자')}: {author}
         </p>
         <p>
-          {t('작성 날짜')}: {formatDate(createdAt).format('YYYY/MM/DD (ddd) A h:mm')}
+          {t('작성 날짜')}: {formatDate ? formatDate({ date: createdAt, format: 'time' }) : ''}
         </p>
       </div>
     </div>

--- a/app/[locale]/community/notice/components/NoticeListRow.tsx
+++ b/app/[locale]/community/notice/components/NoticeListRow.tsx
@@ -5,6 +5,7 @@ import CheckboxOrange from '@/public/image/checkbox_orange.svg';
 import ClipIcon from '@/public/image/clip_icon.svg';
 import LockIcon from '@/public/image/lock_icon.svg';
 import PinIcon from '@/public/image/pin_icon.svg';
+import { useDayjs } from '@/utils/hooks/useDayjs';
 import { getPath } from '@/utils/page';
 
 interface NoticeListRowProps {
@@ -130,17 +131,10 @@ function TitleCell({ title, hasAttachment, id, isEditMode, isPinned }: TitleCell
 }
 
 function DateCell({ date }: { date: string }) {
+  const formatDate = useDayjs();
   return (
     <span className={`${NOTICE_ROW_CELL_WIDTH.date} tracking-wide sm:pl-8 sm:pr-10`}>
-      {formatDate(new Date(date))}
+      {formatDate ? formatDate({ date: date, format: 'simple' }) : ''}
     </span>
   );
 }
-
-const formatDate = (date: Date) => {
-  const yyyy = String(date.getFullYear()).padStart(4, '0');
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-
-  return `${yyyy}/${mm}/${dd}`; // e.g. 2023/08/01
-};

--- a/app/[locale]/community/seminar/components/SeminarRow.tsx
+++ b/app/[locale]/community/seminar/components/SeminarRow.tsx
@@ -73,7 +73,7 @@ function DateAndLocationCell({ date, location }: { date: Date; location: string 
     <div className="flex flex-wrap gap-0.5 hover:cursor-pointer">
       <IconTextWrapper>
         <IconWrapper IconComponent={Calendar} />
-        <Text text={formatDate(date).format('M/DD (ddd) HH:mm')} />
+        <Text text={formatDate ? formatDate({ date: date, format: 'time' }) : ''} />
       </IconTextWrapper>
       <VerticalDivider />
       <IconTextWrapper>

--- a/app/[locale]/components/NewsCard.tsx
+++ b/app/[locale]/components/NewsCard.tsx
@@ -21,7 +21,7 @@ export default function NewsCard({ news }: { news: MainNews }) {
           {news.title}
         </h3>
         <time className="mt-3 block text-sm font-normal text-neutral-500">
-          {formatDate(news.createdAt).format('YYYY.MM.DD')}
+          {formatDate ? formatDate({ date: news.createdAt, format: 'simple' }) : ''}
         </time>
         <p className="mt-3 line-clamp-4 text-sm font-normal leading-[150%] text-neutral-500">
           {news.description}

--- a/app/[locale]/components/NoticeSection.tsx
+++ b/app/[locale]/components/NoticeSection.tsx
@@ -64,7 +64,7 @@ export default function NoticeSection({ allMainNotice }: { allMainNotice: AllMai
             >
               <h3 className="truncate sm:w-[27rem]">{notice.title}</h3>
               <p className="whitespace-nowrap">
-                {formatDate(notice.createdAt).format('MM/DD (ddd)')}
+                {formatDate ? formatDate({ date: notice.createdAt, format: 'day' }) : ''}
               </p>
             </Link>
           ))}

--- a/utils/hooks/useDayjs.ts
+++ b/utils/hooks/useDayjs.ts
@@ -3,8 +3,32 @@ import 'dayjs/locale/ko';
 import dayjs from 'dayjs';
 import { useLocale } from 'next-intl';
 
+type FormatType = 'simple' | 'day' | 'time';
+type DayjsParams = { date: string | Date; format: FormatType };
+
+const FORMAT_MAP: Record<FormatType, Record<'ko' | 'en', string>> = {
+  simple: {
+    ko: 'YYYY/M/DD',
+    en: 'YYYY/M/DD',
+  },
+  day: {
+    ko: 'YYYY/M/DD (ddd)',
+    en: 'YYYY/M/DD ddd',
+  },
+  time: {
+    ko: 'YYYY/M/DD (ddd) A hh:mm',
+    en: 'YYYY/M/DD ddd hh:mm A',
+  },
+};
+
 export const useDayjs = () => {
   const locale = useLocale();
 
-  return (date: string | Date) => dayjs(date).locale(locale);
+  if (!(locale === 'ko') && !(locale === 'en')) return;
+
+  return ({ date, format }: DayjsParams) => {
+    const dayjsInstance = dayjs(date).locale(locale);
+
+    return dayjsInstance.format(FORMAT_MAP[format][locale]);
+  };
 };


### PR DESCRIPTION
close #369

## 작업 내용

```typescript
simple: {
    ko: 'YYYY/M/DD',
    en: 'YYYY/M/DD',
  },
  day: {
    ko: 'YYYY/M/DD (ddd)',
    en: 'YYYY/M/DD ddd',
  },
  time: {
    ko: 'YYYY/M/DD (ddd) A hh:mm',
    en: 'YYYY/M/DD ddd hh:mm A',
  }
```
이슈에서 적어준 서식대로 반영해서 고쳤습니다.

고치는 건 다 고쳤는데, 이제보니까 작은 단위의 컴포넌트들 중, client와 server가 혼재된 경우도 있고, 'use client' directive 없이 선언된 client component가 상위 컴포넌트에서 선언된 'use client'로 암시적인 의존 관계도 있네요. 관련해서 next 공식 문서좀 읽다가 늦어졌습니다 😅. 이건 따로 이슈 올리겠습니다.

## 테스트 방법

페이지 내에서 date가 표시되는 곳들이 locale 변경 시 따라서 잘 바뀌는지 테스트하기
