### PR TITLE
♻️ 페이지별 권한 처리 함수 리팩터링

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,33 +2,13 @@ import { NextRequest } from 'next/server';
 import createMiddleware from 'next-intl/middleware';
 
 import { BASE_URL, isProd } from '@/constants/env';
-import { UserState } from '@/contexts/SessionContext';
 import { routing } from '@/i18n/routing';
 
 import { getUserState } from './actions/session';
 import { PROD_LOGIN_URL } from './constants/network';
+import { getRequiredAuth } from './utils/auth';
 
 const handleI18nRouting = createMiddleware(routing);
-
-/** 페이지별 권한 검사 */
-/** 권한간의 계층관계가 명확하지 않으므로(요구사항이 바뀔 수도 있으므로) 배열로 반환 */
-const getRequiredAuth = (pathname: string): UserState[] => {
-  if (pathname.startsWith('/en')) pathname = pathname.slice(3);
-
-  const isCouncilPage = pathname.includes('/council');
-  const isCreateOrEditPage = pathname.endsWith('create') || pathname.endsWith('edit');
-  const isAdminPage = pathname.startsWith('/admin');
-
-  if (isCouncilPage && isCreateOrEditPage) {
-    return ['ROLE_COUNCIL', 'ROLE_STAFF'];
-  }
-
-  if (isAdminPage || isCreateOrEditPage) {
-    return ['ROLE_STAFF'];
-  }
-
-  return ['ROLE_STAFF', 'ROLE_RESERVATION', 'ROLE_COUNCIL', 'logout'];
-};
 
 export default async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -7,9 +7,13 @@ import { UserState } from '@/contexts/SessionContext';
 export const getRequiredAuth = (pathname: string): UserState[] => {
   if (pathname.startsWith('/en')) pathname = pathname.slice(3);
 
-  const isCouncilPage = pathname.includes('/council');
-  const isCreateOrEditPage = pathname.endsWith('create') || pathname.endsWith('edit');
-  const isAdminPage = pathname.startsWith('/admin');
+  const segments = pathname.split('/').filter(Boolean);
+  const firstSegment = segments[0];
+  const lastSegment = segments.at(-1);
+
+  const isCouncilPage = segments.includes('council');
+  const isCreateOrEditPage = lastSegment === 'create' || lastSegment === 'edit';
+  const isAdminPage = firstSegment === 'admin';
 
   if (isCouncilPage && isCreateOrEditPage) {
     return ['ROLE_COUNCIL', 'ROLE_STAFF'];

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,0 +1,23 @@
+import { UserState } from '@/contexts/SessionContext';
+
+/**
+ * 페이지별 권한 검사
+ * 권한간의 계층관계가 명확하지 않으므로(요구사항이 바뀔 수도 있으므로) 배열로 반환
+ */
+export const getRequiredAuth = (pathname: string): UserState[] => {
+  if (pathname.startsWith('/en')) pathname = pathname.slice(3);
+
+  const isCouncilPage = pathname.includes('/council');
+  const isCreateOrEditPage = pathname.endsWith('create') || pathname.endsWith('edit');
+  const isAdminPage = pathname.startsWith('/admin');
+
+  if (isCouncilPage && isCreateOrEditPage) {
+    return ['ROLE_COUNCIL', 'ROLE_STAFF'];
+  }
+
+  if (isAdminPage || isCreateOrEditPage) {
+    return ['ROLE_STAFF'];
+  }
+
+  return ['ROLE_STAFF', 'ROLE_RESERVATION', 'ROLE_COUNCIL', 'logout'];
+};


### PR DESCRIPTION
close #339

## 작업 내용

미들웨어에서 번잡하게 체크하던 페이지별 권한 함수를 정리하고 별도 파일로 분리합니다. 

기존 목표는 모든 페이지의 SegmentNode를 만들어 거기서 접근 가능한 페이지를 명시하는거였는데, 생성/편집페이지의 SegmentNode를 모두 만들어야하고 url에서 권한을 파악하는 지금 방식이 유효해보여 기존 방식에서 리팩터링만 진행했습니다.

## 테스트 방법

권한별로 페이지 접근 가능한지 테스트
