### PR TITLE
🐛 세미나 편집시 description이 introduction에 유입되는 버그 픽스

### DIFF
--- a/app/[locale]/community/seminar/[id]/edit/EditSeminarPageContent.tsx
+++ b/app/[locale]/community/seminar/[id]/edit/EditSeminarPageContent.tsx
@@ -57,7 +57,7 @@ export default function EditSeminarPageContent({ id, data }: { id: number; data:
             title: content.title,
             titleForMain: content.titleForMain || null,
             description: content.description || null,
-            introduction: content.description || null,
+            introduction: content.introduction || null,
             name: content.name || null,
             speakerURL: content.speakerURL || null,
             speakerTitle: content.speakerTitle || null,


### PR DESCRIPTION
close #

## 작업 내용

```
description: content.description || null,
introduction: content.description || null,
```

로 되어있어서 편집시 내용 오염이 발생했었네요.


## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->
