### PR TITLE
✨ 영어 description 필수 처리, form 에러 표시 전략 수정

### DIFF
--- a/app/[locale]/about/components/AboutEditor.tsx
+++ b/app/[locale]/about/components/AboutEditor.tsx
@@ -57,8 +57,20 @@ export default function AboutEditor({
         <LanguagePicker onChange={setLanguage} selected={language} />
 
         <Fieldset.HTML>
-          {language === 'ko' && <Form.HTML name="htmlKo" options={{ required: true }} />}
-          {language === 'en' && <Form.HTML name="htmlEn" />}
+          <Form.HTML
+            name="htmlKo"
+            options={{
+              required: { value: true, message: '한국어 내용을 입력해주세요.' },
+            }}
+            isHidden={language === 'en'}
+          />
+          <Form.HTML
+            name="htmlEn"
+            options={{
+              required: { value: true, message: '영문 내용을 입력해주세요.' },
+            }}
+            isHidden={language === 'ko'}
+          />
         </Fieldset.HTML>
 
         <Fieldset.Image>

--- a/components/form/Action.tsx
+++ b/components/form/Action.tsx
@@ -13,12 +13,13 @@ interface Props {
 
 export default function Action({ onCancel, onDelete, onSubmit, submitLabel }: Props) {
   const {
-    formState: { isSubmitting, isDirty, isValid },
+    formState: { isSubmitting, isDirty },
   } = useFormContext();
   const { openModal } = useModal();
 
   return (
-    <div className="mb-6 flex justify-end gap-3">
+    <div className="relative mb-6 flex items-center justify-end gap-3">
+      <ErrorMessages />
       <GrayButton
         title="취소"
         disabled={isSubmitting}
@@ -41,11 +42,21 @@ export default function Action({ onCancel, onDelete, onSubmit, submitLabel }: Pr
           }}
         />
       )}
-      <BlackButton
-        title={submitLabel ?? '저장하기'}
-        disabled={!isValid || isSubmitting}
-        onClick={onSubmit}
-      />
+      <BlackButton title={submitLabel ?? '저장하기'} disabled={isSubmitting} onClick={onSubmit} />
     </div>
   );
 }
+
+const ErrorMessages = () => {
+  const {
+    formState: { errors },
+  } = useFormContext();
+
+  return (
+    <ul className="text-md text-[#FF0000]">
+      {Object.values(errors).map((error, idx) => (
+        <li key={idx}>{error?.message?.toString()}</li>
+      ))}
+    </ul>
+  );
+};

--- a/components/form/html/HTMLEditor.tsx
+++ b/components/form/html/HTMLEditor.tsx
@@ -15,11 +15,12 @@ import { isContentEmpty } from '@/utils/post';
 
 export interface HTMLEditorProps {
   name: string;
+  isHidden?: boolean;
   options?: RegisterOptions;
 }
 
 // MEMO: defaultValues에 비동기 함수를 건네도 동작할지 모르겠음.
-export default function HTMLEditor({ name, options: registerOptions }: HTMLEditorProps) {
+export default function HTMLEditor({ name, isHidden, options: registerOptions }: HTMLEditorProps) {
   const { register, setValue, getValues } = useFormContext();
   const [div, setDiv] = useState<HTMLDivElement | null>(null);
   const { onBlur } = register(name, registerOptions);
@@ -33,7 +34,6 @@ export default function HTMLEditor({ name, options: registerOptions }: HTMLEdito
     editor.onChange = (contents) => {
       setValue(name, isContentEmpty(editor) ? '' : contents, {
         shouldDirty: true,
-        shouldValidate: true,
       });
     };
 
@@ -44,6 +44,8 @@ export default function HTMLEditor({ name, options: registerOptions }: HTMLEdito
       return;
     };
   }, [div, getValues, name, onBlur, setValue]);
+
+  if (isHidden) return null;
 
   return <div ref={setDiv} />;
 }


### PR DESCRIPTION
## 작업 내용

Form 에러 처리 방법을 수정합니다. 일단 소개탭 일부에만 적용했고 리뷰 완료되면 다른 에디터에도 적용하겠습니다.

에러 내용을 토스트 대신 텍스트로 표시합니다. 토스트가 사라지면 에러 내용을 다시 확인할 수 없기도 하고, 텍스트는 에러가 해결됐을 때 해당 에러 텍스트를 즉각적으로 없앨 수 있어 텍스트가 낫다고 판단했습니다.

제출 버튼을 항상 활성화시킵니다. 제출 버튼 클릭 시점에 에러가 있다면 에러 텍스트를 띄우고 제출을 막습니다. 

컴포넌트 표시 여부에 상관없이 필드 register가 되게하기위해 Form.HTML 내부에서 visible 유무를 처리합니다.

Note: 에러 메시지 디자인 필요

https://react-hook-form.com/docs/useform#mode

## 테스트 방법

AboutEditor가 사용되는 소개탭 에디터에서 영어 본문이 없으면 제출이 불가해야합니다. 에디터 화면 진입 후 영어 본문 에디터가 표시되지 않았더라도 validation이 올바르게 이루어져야합니다. 
