### PR TITLE
📆 공지글 고정, 만료기간 추가

### DIFF
--- a/apis/types/notice.ts
+++ b/apis/types/notice.ts
@@ -20,6 +20,8 @@ export interface Notice {
   tags: string[];
   isPinned: boolean;
   isImportant: boolean;
+  pinnedUntil: Date;
+  importantUntil: Date;
   author: string;
 
   id: number;

--- a/app/[locale]/community/notice/[id]/edit/EditNoticePageContent.tsx
+++ b/app/[locale]/community/notice/[id]/edit/EditNoticePageContent.tsx
@@ -30,6 +30,8 @@ export default function EditNoticePageContent({ id, data }: { id: number; data: 
     isPrivate: data.isPrivate,
     isImportant: data.isImportant,
     isPinned: data.isPinned,
+    pinnedUntil: data.pinnedUntil ? new Date(data.pinnedUntil) : new Date(),
+    importantUntil: data.importantUntil ? new Date(data.importantUntil) : new Date(), 
   };
 
   const onCancel = () => router.push(`${noticePath}/${id}`);
@@ -55,13 +57,15 @@ export default function EditNoticePageContent({ id, data }: { id: number; data: 
             isPrivate: content.isPrivate,
             isPinned: content.isPinned,
             isImportant: content.isImportant,
+            pinnedUntil: content.pinnedUntil.toISOString().slice(0, 10), 
+            importantUntil: content.importantUntil.toISOString().slice(0, 10),
             tags: content.tags,
             deleteIds,
           }),
         ],
         {
           type: 'application/json',
-        },
+        }
       ),
     );
 

--- a/app/[locale]/community/notice/components/NoticeEditor.tsx
+++ b/app/[locale]/community/notice/components/NoticeEditor.tsx
@@ -14,6 +14,8 @@ export interface NoticeFormData {
   isPrivate: boolean;
   isPinned: boolean;
   isImportant: boolean;
+  pinnedUntil: Date;
+  importantUntil: Date;
 }
 
 interface Props {
@@ -34,6 +36,8 @@ export default function NoticeEditor({ defaultValues, onCancel, onSubmit, onDele
       isPrivate: false,
       isPinned: false,
       isImportant: false,
+      pinnedUntil: new Date(),
+      importantUntil: new Date(),
     },
   });
   const { handleSubmit, setValue } = formMethods;
@@ -88,12 +92,22 @@ export default function NoticeEditor({ defaultValues, onCancel, onSubmit, onDele
                 if (isImportant) setValue('isPrivate', false);
               }}
             />
+            <Form.Date
+              name="pinnedUntil"
+              enablePast
+              hideTime
+            />
             <Form.Checkbox
               label="메인-중요 안내에 표시"
               name="isImportant"
               onChange={(isImportant) => {
                 if (isImportant) setValue('isPrivate', false);
               }}
+            />
+            <Form.Date
+              name="importantUntil"
+              enablePast
+              hideTime
             />
           </div>
         </Fieldset>

--- a/app/[locale]/community/notice/create/page.tsx
+++ b/app/[locale]/community/notice/create/page.tsx
@@ -32,6 +32,8 @@ export default function NoticeCreatePage() {
             isPrivate: content.isPrivate,
             isPinned: content.isPinned,
             isImportant: content.isImportant,
+            pinnedUntil: content.pinnedUntil.toISOString().slice(0, 10), 
+            importantUntil: content.importantUntil.toISOString().slice(0, 10),
             tags: content.tags,
           }),
         ],


### PR DESCRIPTION
close #382 

## 작업 내용
공지글 고정이 가능하도록 pinnedUntil, importantUntil 추가 하였고,
Form.Date가 Date 형식밖에 안돼서, submit할 때 string 형식으로 변경하였습니다.
기존에 데이터의 경우, pinnedUntil, importantUntil 값이 null이라 오류가 발생하기 때문에,
그런 경우에는 현재 날짜로 데이터 처리하였습니다.

## 테스트 방법
관리자 모드에서 공지사항 편집, 공지사항 작성 진행
