### PR TITLE
✨ 검색 엔진 차단을 위한 robots.txt를 작성합니다.

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -8,7 +8,7 @@ module.exports = {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/admin/', '/.internal/', '/.next/', '/reservations/', '/search'],
+        disallow: ['/admin/', '/.internal/', '/reservations/', '/search'],
       },
     ],
   },

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -8,6 +8,7 @@ module.exports = {
       {
         userAgent: '*',
         allow: '/',
+        disallow: ['/admin/', '/.internal/', '/.next/', '/reservations/', '/search'],
       },
     ],
   },


### PR DESCRIPTION
close #411

## 작업 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->
현재 컴퓨터 공학부 페이지는 구글에 노출되는 개인정보가 보이지는 않습니다.

예시 1.
<img width="911" alt="image" src="https://github.com/user-attachments/assets/849e31f9-b9ff-4a10-b0a2-081c020a1f66" />

예시 2.
<img width="913" alt="image" src="https://github.com/user-attachments/assets/9dddd23f-a4b9-4a41-a9a6-7641ebc75826" />
<img width="932" alt="Screenshot 2025-07-06 at 22 01 59" src="https://github.com/user-attachments/assets/778e2e84-00eb-4fc3-abd2-8471bca3cb12" />

pdf의 경우 여러 파일들이 나왔으나 주민등록번호와 같은 민감한 개인 정보는 따로 없었습니다. xls 또한 마찬가지였고, 다른 파일 확장자는 검색되지 않았어요!

생긴지 얼마 안 된 홈페이지다보니 민감 정보가 올라온 불상사는 없어보입니다(우선은).

그래서 robots.txt에 선제적으로 검색 엔진이 크롤링하면 안 되거나, 혹은 할 필요가 없는 페이지들을 적어 넣으면 될 것 같아요.

후보군  
1. /admin/
2. /.internal/
3. /reservations/
4. /search

이 외에도 추가로 넣으면 좋을 것 같은 페이지를 알려주시면 감사하겠습니다~

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->
