### PR TITLE
🐛 연구실 정보 중 웹사이트 반영 안 되는 오류 수정

### DIFF
--- a/app/[locale]/research/labs/components/ResearchLabEditor.tsx
+++ b/app/[locale]/research/labs/components/ResearchLabEditor.tsx
@@ -108,7 +108,7 @@ export default function ResearchLabEditor({
           </Fieldset>
           <Fieldset title="웹사이트 주소" mb="mb-6" titleMb="mb-2">
             <Form.Text
-              name="website"
+              name="websiteURL"
               maxWidth="w-[21.75rem]"
               placeholder="예: https://www.example.com"
             />

--- a/app/[locale]/research/labs/components/ResearchLabEditor.tsx
+++ b/app/[locale]/research/labs/components/ResearchLabEditor.tsx
@@ -107,7 +107,11 @@ export default function ResearchLabEditor({
             <Form.Text name="tel" maxWidth="w-[21.75rem]" placeholder="예: (02) 880-7302" />
           </Fieldset>
           <Fieldset title="웹사이트 주소" mb="mb-6" titleMb="mb-2">
-            <Form.Text name="webtie" maxWidth="w-[21.75rem]" placeholder="예: (02) 880-7302" />
+            <Form.Text
+              name="website"
+              maxWidth="w-[21.75rem]"
+              placeholder="예: https://www.example.com"
+            />
           </Fieldset>
         </div>
 


### PR DESCRIPTION
close #

## 작업 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->
- form의 `name`에 오타가 있어 `react-hook-form`에서 웹사이트 입력폼을 제대로 인식하지 못하고 있었음.
  - 오타 수정하여 해결
- `placeholder`도 알맞은 내용으로 수정

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->
- 연구실 편집했을 때 웹사이트 정보가 제대로 반영되는지 확인
