### PR TITLE
🐛 FacultyEditor 종료날짜 필드값 endDate로 정상화

### DIFF
--- a/app/[locale]/people/faculty/components/FacultyEditor.tsx
+++ b/app/[locale]/people/faculty/components/FacultyEditor.tsx
@@ -223,7 +223,7 @@ const DateSection = ({ language }: { language: Language }) => {
           <Form.Date name={`${language}.startDate`} hideTime enablePast disabled={isDisabled} />
         </Fieldset>
         <Fieldset title="종료 날짜" titleMb="mb-2">
-          <Form.Date name={`${language}.startDate`} hideTime enablePast disabled={isDisabled} />
+          <Form.Date name={`${language}.endDate`} hideTime enablePast disabled={isDisabled} />
         </Fieldset>
       </div>
     </Form.Section>


### PR DESCRIPTION
close #

## 작업 내용

<!-- 변경된 코드와 그 이유를 작성합니다. -->
- `FacultyEditor`에 종료날짜도 `startDate` 값으로 들어가있던 오류 `endDate`로 변경하여 해결

## 테스트 방법

<!-- 올바르게 작동함을 리뷰어가 확인할 수 있는 방법을 써주세요. -->
- 역대 교수진 편집 중 재직 기간 필드가 정상적으로 동작하는지 확인
